### PR TITLE
Preparation for the first GitHub release, 2.2-01

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,13 +4,20 @@ NOTES.md
 MARKETPLACE.md
 optimized
 
+# Release
+AVsitter2/AVsitter2.zip
+
 # Compressed/optimized LSL scripts
 *.lslz
+*.lslo
 
 .project
 .buildpath
 .settings
 .externalToolBuilders
+
+# Linux backup files
+*~
 
 # Windows image file caches
 Thumbs.db

--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,12 @@ optimized
 
 # Release
 AVsitter2/AVsitter2.zip
+AVsitter2/AVsitter2-oss.zip
 
-# Compressed/optimized LSL scripts
+# Compressed/optimized/processed LSL scripts
 *.lslz
 *.lslo
+*.oss
 
 .project
 .buildpath

--- a/AVsitter2/Makefile
+++ b/AVsitter2/Makefile
@@ -1,0 +1,73 @@
+# Configuration area
+
+# Full path to Python. For Windows this is typically
+# C:\Python27\python.exe; if it is in your path you don't need to change it.
+PYTHON=python
+
+# Full path to main.py in the optimizer. Depends on where it was unpacked.
+OPTIMIZER=/l/pyoptimizer/main.py
+
+# Which preprocessor to use. Use 'gcpp' for GNU cpp (typical on Linux);
+# use 'mcpp' for mcpp.
+PREPROC_KIND=mcpp
+
+# Full path to the preprocessor. Depends on where you have downloaded it.
+# If the preprocessor is mcpp and it is in your path, you can leave it as is.
+PREPROC_PATH=mcpp
+
+# Command to remove files in your system. Use 'del' for Windows.
+RM=rm -f
+
+# Name of the zipped file to generate
+ZIP=AVsitter2.zip
+
+# End of configuration area
+
+
+
+# Note some of these scripts don't strictly need to be optimized for memory.
+
+OPTIMIZED=[AV]sitA.lslo\
+ [AV]sitB.lslo\
+ [AV]adjuster.lslo\
+ [AV]helper.lslo\
+ [AV]root-security.lslo\
+ [AV]root.lslo\
+ [AV]select.lslo\
+ Plugins/AVcamera/[AV]camera.lslo\
+ Plugins/AVcontrol/LockGuard/[AV]LockGuard-object.lslo\
+ Plugins/AVcontrol/LockGuard/[AV]LockGuard.lslo\
+ Plugins/AVcontrol/Xcite!-Sensations/[AV]Xcite!.lslo\
+ Plugins/AVcontrol/[AV]root-RLV-extra.lslo\
+ Plugins/AVcontrol/[AV]root-RLV.lslo\
+ Plugins/AVcontrol/[AV]root-control.lslo\
+ Plugins/AVfaces/[AV]faces.lslo\
+ Plugins/AVprop/[AV]menu.lslo\
+ Plugins/AVprop/[AV]prop.lslo\
+ Plugins/AVprop/[AV]object.lslo\
+ Plugins/AVsequence/[AV]sequence.lslo\
+ Utilities/AVpos-generator.lslo\
+ Utilities/AVpos-shifter.lslo\
+ Utilities/Anim-perm-checker.lslo\
+ Utilities/MLP-converter.lslo\
+ Utilities/Missing-anim-finder.lslo\
+ Utilities/Updater/update-receiver.lslo\
+ Utilities/Updater/update-sender.lslo
+
+UNOPTIMIZED=
+
+all: $(ZIP)
+
+clean:
+	$(RM) $(ZIP) $(OPTIMIZED)
+
+optimized: $(OPTIMIZED)
+
+$(ZIP): $(OPTIMIZED) $(UNOPTIMIZED)
+	$(RM) $@
+	zip $@ $(OPTIMIZED) $(UNOPTIMIZED)
+
+%.lslo: %.lsl
+	$(PYTHON) $(OPTIMIZER) -H -O addstrings,shrinknames,-extendedglobalexpr -p $(PREPROC_KIND) --precmd=$(PREPROC_PATH) $< -o $@
+
+.PHONY : all clean optimized

--- a/AVsitter2/Makefile
+++ b/AVsitter2/Makefile
@@ -18,8 +18,11 @@ PREPROC_PATH=mcpp
 # Command to remove files in your system. Use 'del' for Windows.
 RM=rm -f
 
-# Name of the zipped file to generate
-ZIP=AVsitter2.zip
+# Name of the zipped file to generate for SL
+SLZIP=AVsitter2.zip
+
+# Name of the zipped file to generate for OpenSim
+OSZIP=AVsitter2-oss.zip
 
 # End of configuration area
 
@@ -56,18 +59,32 @@ OPTIMIZED=[AV]sitA.lslo\
 
 UNOPTIMIZED=
 
-all: $(ZIP)
+OPENSIM=[AV]sitA.oss\
+ [AV]sitB.oss\
+ [AV]adjuster.oss\
+ [AV]helper.oss
+
+all: $(SLZIP) $(OSZIP)
 
 clean:
-	$(RM) $(ZIP) $(OPTIMIZED)
+	$(RM) $(SLZIP) $(OSZIP) $(OPTIMIZED) $(OPENSIM)
 
 optimized: $(OPTIMIZED)
 
-$(ZIP): $(OPTIMIZED) $(UNOPTIMIZED)
+opensim: $(OPENSIM)
+
+$(SLZIP): $(OPTIMIZED) $(UNOPTIMIZED)
 	$(RM) $@
 	zip $@ $(OPTIMIZED) $(UNOPTIMIZED)
 
 %.lslo: %.lsl
 	$(PYTHON) $(OPTIMIZER) -H -O addstrings,shrinknames,-extendedglobalexpr -p $(PREPROC_KIND) --precmd=$(PREPROC_PATH) $< -o $@
+
+$(OSZIP): $(OPENSIM)
+	$(RM) $@
+	zip $@ $(OPENSIM)
+
+%.oss: %.lsl
+	$(PYTHON) prepare-for-oss.py $< > $@
 
 .PHONY : all clean optimized

--- a/AVsitter2/Plugins/AVcamera/[AV]camera.lsl
+++ b/AVsitter2/Plugins/AVcamera/[AV]camera.lsl
@@ -123,8 +123,8 @@ default
             if (num == 90230 | num == 90231)
             {
                 list data = llParseStringKeepNulls(id, ["|"], []);
-                key this_controller = (key)llList2String(data, 0);
-                key this_sitter = (key)llList2String(data, -1);
+                key this_controller = llList2Key(data, 0);
+                key this_sitter = llList2Key(data, -1);
                 if (this_sitter == mySitter)
                 {
                     myPose = msg;
@@ -143,7 +143,7 @@ default
             else if (num == 90045)
             {
                 list data = llParseStringKeepNulls(msg, ["|"], []);
-                integer sitter = (integer)llList2String(data, 0);
+                integer sitter = llList2Integer(data, 0);
                 if (sitter == SCRIPT_CHANNEL)
                 {
                     mySitter = id;

--- a/AVsitter2/Plugins/AVcamera/[AV]camera.lsl
+++ b/AVsitter2/Plugins/AVcamera/[AV]camera.lsl
@@ -55,7 +55,7 @@ Readout_Say(string say, string SCRIPT_CHANNEL)
 
 set_camera(integer byButton)
 {
-    if (mySitter)
+    if (mySitter) // OSS::if (osIsUUID(mySitter) && mySitter != NULL_KEY)
     {
         if (llGetPermissions() & PERMISSION_CONTROL_CAMERA)
         {

--- a/AVsitter2/Plugins/AVcamera/[AV]camera.lsl
+++ b/AVsitter2/Plugins/AVcamera/[AV]camera.lsl
@@ -3,15 +3,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this 
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) the AVsitter Contributors (http://avsitter.github.io)
+ * Copyright © the AVsitter Contributors (http://avsitter.github.io)
  * AVsitter™ is a trademark. For trademark use policy see:
  * https://avsitter.github.io/TRADEMARK.mediawiki
- * 
+ *
  * Please consider supporting continued development of AVsitter and
  * receive automatic updates and other benefits! All details and user 
  * instructions can be found at http://avsitter.github.io
  */
- 
+
 string version = "2.2";
 string notecard_name = "AVpos";
 string main_script = "[AV]sitA";
@@ -26,6 +26,7 @@ list camera_triggers;
 list camera_settings;
 integer lastByButton = -1;
 string lastPose;
+
 integer get_number_of_scripts()
 {
     integer i = 1;
@@ -35,7 +36,9 @@ integer get_number_of_scripts()
     }
     return i;
 }
+
 integer verbose = 0;
+
 Out(integer level, string out)
 {
     if (verbose >= level)
@@ -43,11 +46,13 @@ Out(integer level, string out)
         llOwnerSay(llGetScriptName() + "[" + version + "] " + out);
     }
 }
+
 Readout_Say(string say, string SCRIPT_CHANNEL)
 {
     llSleep(0.2);
     llMessageLinked(LINK_THIS, 90022, say, SCRIPT_CHANNEL);
 }
+
 set_camera(integer byButton)
 {
     if (mySitter)
@@ -57,7 +62,7 @@ set_camera(integer byButton)
             if (llGetPermissionsKey() == mySitter)
             {
                 integer index = llListFindList(camera_triggers, [myPose]);
-                if (!~index)
+                if (index == -1)
                 {
                     if (~lastByButton)
                     {
@@ -89,6 +94,7 @@ set_camera(integer byButton)
         llRequestPermissions(mySitter, PERMISSION_CONTROL_CAMERA);
     }
 }
+
 default
 {
     run_time_permissions(integer perm)
@@ -98,6 +104,7 @@ default
             set_camera(FALSE);
         }
     }
+
     state_entry()
     {
         SCRIPT_CHANNEL = (integer)llGetSubString(llGetScriptName(), llSubStringIndex(llGetScriptName(), " "), -1);
@@ -108,6 +115,7 @@ default
             notecard_query = llGetNotecardLine(notecard_name, 0);
         }
     }
+
     link_message(integer sender, integer num, string msg, key id)
     {
         if (sender == llGetLinkNumber())
@@ -193,6 +201,7 @@ default
             }
         }
     }
+
     changed(integer change)
     {
         if (change & CHANGED_INVENTORY)
@@ -203,6 +212,7 @@ default
             }
         }
     }
+
     dataserver(key query_id, string data)
     {
         if (query_id == notecard_query)

--- a/AVsitter2/Plugins/AVcontrol/LockGuard/[AV]LockGuard-object.lsl
+++ b/AVsitter2/Plugins/AVcontrol/LockGuard/[AV]LockGuard-object.lsl
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this 
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) the AVsitter Contributors (http://avsitter.github.io)
+ * Copyright © the AVsitter Contributors (http://avsitter.github.io)
  * AVsitter™ is a trademark. For trademark use policy see:
  * https://avsitter.github.io/TRADEMARK.mediawiki
  *

--- a/AVsitter2/Plugins/AVcontrol/LockGuard/[AV]LockGuard.lsl
+++ b/AVsitter2/Plugins/AVcontrol/LockGuard/[AV]LockGuard.lsl
@@ -128,7 +128,7 @@ default
         if (num == 90500 && USES_PROPS)
         {
             list data = llParseStringKeepNulls(msg, ["|"], []);
-            integer SITTER_NUMBER = (integer)llList2String(data, 1);
+            integer SITTER_NUMBER = llList2Integer(data, 1);
             if (SITTER_NUMBER == SITTER)
             {
                 avatar = id;

--- a/AVsitter2/Plugins/AVcontrol/LockGuard/[AV]LockGuard.lsl
+++ b/AVsitter2/Plugins/AVcontrol/LockGuard/[AV]LockGuard.lsl
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this 
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) the AVsitter Contributors (http://avsitter.github.io)
+ * Copyright © the AVsitter Contributors (http://avsitter.github.io)
  * AVsitter™ is a trademark. For trademark use policy see:
  * https://avsitter.github.io/TRADEMARK.mediawiki
  *
@@ -11,7 +11,7 @@
  * receive automatic updates and other benefits! All details and user 
  * instructions can be found at http://avsitter.github.io
  */
- 
+
 //  For use attaching particle chains to LockGuard V2 compatible cuffs such as Open Collar
 //  This script should be placed inside the prim that contains your poses and props.
 //  Inspiration and function (not code) from the Bright CISS system by Shan Bright & Innula Zenovka.

--- a/AVsitter2/Plugins/AVcontrol/Xcite!-Sensations/[AV]Xcite!.lsl
+++ b/AVsitter2/Plugins/AVcontrol/Xcite!-Sensations/[AV]Xcite!.lsl
@@ -125,9 +125,9 @@ default
                     {
                         if (DEBUG)
                         {
-                            Out(0, "Setting " + name + "'s tilt to " + (string)llList2Integer(XCITE_TILT, index));
+                            Out(0, "Setting " + name + "'s tilt to " + llList2String(XCITE_TILT, index));
                         }
-                        llMessageLinked(LINK_SET, 20020, name + "|" + (string)llList2Integer(XCITE_TILT, index), "");
+                        llMessageLinked(LINK_SET, 20020, name + "|" + llList2String(XCITE_TILT, index), "");
                     }
                     else
                     {

--- a/AVsitter2/Plugins/AVcontrol/Xcite!-Sensations/[AV]Xcite!.lsl
+++ b/AVsitter2/Plugins/AVcontrol/Xcite!-Sensations/[AV]Xcite!.lsl
@@ -43,7 +43,7 @@ string parse_text(string say)
     integer i;
     for (i = 0; i < llGetListLength(SITTERS); i++)
     {
-        string sitter_name = llList2String(llParseString2List(llKey2Name(llList2String(SITTERS, i)), [" "], []), 0);
+        string sitter_name = llList2String(llParseString2List(llKey2Name(llList2Key(SITTERS, i)), [" "], []), 0);
         if (sitter_name == "")
         {
             sitter_name = "(nobody)";

--- a/AVsitter2/Plugins/AVcontrol/Xcite!-Sensations/[AV]Xcite!.lsl
+++ b/AVsitter2/Plugins/AVcontrol/Xcite!-Sensations/[AV]Xcite!.lsl
@@ -3,15 +3,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this 
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) the AVsitter Contributors (http://avsitter.github.io)
+ * Copyright © the AVsitter Contributors (http://avsitter.github.io)
  * AVsitter™ is a trademark. For trademark use policy see:
  * https://avsitter.github.io/TRADEMARK.mediawiki
- * 
+ *
  * Please consider supporting continued development of AVsitter and
  * receive automatic updates and other benefits! All details and user 
  * instructions can be found at http://avsitter.github.io
  */
- 
+
 string product = "AVsitter™ Xcite!";
 string version = "1.02";
 string notecard_name = "[AV]Xcite_settings";
@@ -27,6 +27,7 @@ string CURRENT_POSE;
 list TIMERS;
 list SITTERS;
 integer DEBUG;
+
 Out(integer level, string out)
 {
     if (verbose >= level)
@@ -34,7 +35,9 @@ Out(integer level, string out)
         llOwnerSay(llGetScriptName() + "[" + version + "]:" + out);
     }
 }
+
 key key_request;
+
 string parse_text(string say)
 {
     integer i;
@@ -49,10 +52,12 @@ string parse_text(string say)
     }
     return say;
 }
+
 string strReplace(string str, string search, string replace)
 {
     return llDumpList2String(llParseStringKeepNulls(str, [search], []), replace);
 }
+
 default
 {
     state_entry()
@@ -61,6 +66,7 @@ default
         Out(0, "Loading...");
         notecard_query = llGetNotecardLine(notecard_name, 0);
     }
+
     changed(integer change)
     {
         if (change & CHANGED_INVENTORY)
@@ -78,6 +84,7 @@ default
             }
         }
     }
+
     link_message(integer sender, integer num, string msg, key id)
     {
         if (sender == llGetLinkNumber())
@@ -102,13 +109,13 @@ default
                     CURRENT_POSE = llList2String(data, 1);
                     SITTERS = llParseStringKeepNulls(llList2String(data, 4), ["@"], []);
                     integer index = llListFindList(POSE_AND_SITTER, [CURRENT_POSE + "|" + (string)script_channel]);
-                    if (!~index)
+                    if (index == -1)
                     {
                         index = llListFindList(POSE_AND_SITTER, [CURRENT_POSE + "|*"]);
-                        if (!~index)
+                        if (index == -1)
                         {
                             index = llListFindList(POSE_AND_SITTER, ["*|*"]);
-                            if (!~index)
+                            if (index == -1)
                             {
                                 return;
                             }
@@ -142,6 +149,7 @@ default
             }
         }
     }
+
     timer()
     {
         integer i;
@@ -154,6 +162,7 @@ default
             }
         }
     }
+
     dataserver(key query_id, string data)
     {
         if (query_id == notecard_query)

--- a/AVsitter2/Plugins/AVcontrol/Xcite!-Sensations/[AV]Xcite!.lsl
+++ b/AVsitter2/Plugins/AVcontrol/Xcite!-Sensations/[AV]Xcite!.lsl
@@ -105,7 +105,7 @@ default
                     }
                     llSetTimerEvent(TIMER_DEFAULT);
                     list data = llParseStringKeepNulls(msg, ["|"], []);
-                    integer script_channel = (integer)llList2String(data, 0);
+                    integer script_channel = llList2Integer(data, 0);
                     CURRENT_POSE = llList2String(data, 1);
                     SITTERS = llParseStringKeepNulls(llList2String(data, 4), ["@"], []);
                     integer index = llListFindList(POSE_AND_SITTER, [CURRENT_POSE + "|" + (string)script_channel]);
@@ -178,17 +178,17 @@ default
                 list parts = llParseStringKeepNulls(llGetSubString(data, llSubStringIndex(data, " ") + 1, -1), [" | ", " |", "| ", "|"], []);
                 if (command == "TIMER")
                 {
-                    TIMER_DEFAULT = (integer)llList2String(parts, 0);
+                    TIMER_DEFAULT = llList2Integer(parts, 0);
                 }
                 else if (command == "DEBUG")
                 {
-                    DEBUG = (integer)llList2String(parts, 0);
+                    DEBUG = llList2Integer(parts, 0);
                 }
                 else if (command == "XCITE")
                 {
                     POSE_AND_SITTER += [llStringTrim(llList2String(parts, 0), STRING_TRIM) + "|" + llList2String(parts, 1)];
                     XCITE_COMMANDS += [llList2String(parts, 2) + "|" + llList2String(parts, 3) + "|" + llList2String(parts, 4) + "|" + llList2String(parts, 5)];
-                    XCITE_TILT += (integer)llList2String(parts, 6);
+                    XCITE_TILT += llList2Integer(parts, 6);
                 }
                 notecard_query = llGetNotecardLine(notecard_name, ++notecard_line);
             }

--- a/AVsitter2/Plugins/AVcontrol/[AV]root-RLV-extra.lsl
+++ b/AVsitter2/Plugins/AVcontrol/[AV]root-RLV-extra.lsl
@@ -294,14 +294,14 @@ state running
                 integer i;
                 for (i = 0; i < llGetListLength(CLOTHING_LAYERS); i++)
                 {
-                    if (llList2String(CLOTHING_LAYERS, i))
+                    if (llList2String(CLOTHING_LAYERS, i) != "")
                     {
                         relay(SLAVE, "@remoutfit:" + llList2String(CLOTHING_LAYERS, i) + "=force");
                     }
                 }
                 for (i = 0; i < llGetListLength(ATTACHMENT_POINTS); i++)
                 {
-                    if (llList2String(ATTACHMENT_POINTS, i))
+                    if (llList2String(ATTACHMENT_POINTS, i) != "")
                     {
                         if (i != 2)
                         {

--- a/AVsitter2/Plugins/AVcontrol/[AV]root-RLV-extra.lsl
+++ b/AVsitter2/Plugins/AVcontrol/[AV]root-RLV-extra.lsl
@@ -3,15 +3,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this 
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) the AVsitter Contributors (http://avsitter.github.io)
+ * Copyright © the AVsitter Contributors (http://avsitter.github.io)
  * AVsitter™ is a trademark. For trademark use policy see:
  * https://avsitter.github.io/TRADEMARK.mediawiki
- * 
+ *
  * Please consider supporting continued development of AVsitter and
  * receive automatic updates and other benefits! All details and user 
  * instructions can be found at http://avsitter.github.io
  */
- 
+
 string product;
 string version = "2.2";
 integer RELAY_CHANNEL = -1812221819;
@@ -40,6 +40,7 @@ string iconSubtract = "[➖]";
 string pagedMenuText;
 list pagedMenuButtons;
 integer verbose = 0;
+
 Out(integer level, string out)
 {
     if (verbose >= level)
@@ -47,20 +48,24 @@ Out(integer level, string out)
         llOwnerSay(llGetScriptName() + "[" + version + "]:" + out);
     }
 }
+
 string strReplace(string str, string search, string replace)
 {
     return llDumpList2String(llParseStringKeepNulls(str, [search], []), replace);
 }
+
 list order_buttons(list buttons)
 {
     return llList2List(buttons, -3, -1) + llList2List(buttons, -6, -4) + llList2List(buttons, -9, -7) + llList2List(buttons, -12, -10);
 }
+
 relay(key av, string msg)
 {
     msg = "RLV," + (string)av + "," + msg;
     Out(1, "Sending RLV Command: " + msg);
     llSay(RELAY_CHANNEL, msg);
 }
+
 remove_menu(string worn, list slots)
 {
     list menu_items;
@@ -81,6 +86,7 @@ remove_menu(string worn, list slots)
     }
     new_paged_menu(menu + " menu for " + llKey2Name(SLAVE) + "\n\nThe captive" + text, menu_items);
 }
+
 new_paged_menu(string text, list menu_items)
 {
     pagedMenuText = text;
@@ -88,6 +94,7 @@ new_paged_menu(string text, list menu_items)
     menuPage = 0;
     paged_menu();
 }
+
 paged_menu()
 {
     list MypagedMenuButtons = pagedMenuButtons;
@@ -116,12 +123,14 @@ paged_menu()
     Out(1, "paged menu:" + llDumpList2String(MypagedMenuButtons, ","));
     dialog(pagedMenuText, ["[BACK]"] + MypagedMenuButtons);
 }
+
 dialog(string text, list buttons)
 {
     while (llGetListLength(buttons) % 3)
         buttons += " ";
     llDialog(CONTROLLER, "AVsitter™ RLV " + product + " " + version + "\n\n" + text, order_buttons(buttons), menu_channel);
 }
+
 remove_script(string reason)
 {
     string message = "\n" + llGetScriptName() + " ==Script Removed==\n\n" + reason;
@@ -129,11 +138,13 @@ remove_script(string reason)
     llInstantMessage(llGetOwner(), message);
     llRemoveInventory(llGetScriptName());
 }
+
 main_menu()
 {
     menu = "";
     dialog("Un/Dress menu for " + llKey2Name(SLAVE), ["[BACK]", "Browse #RLV", "Fast Strip", "Undress", "Detach"]);
 }
+
 default
 {
     state_entry()
@@ -148,11 +159,9 @@ default
         }
     }
 }
+
 state running
 {
-    state_entry()
-    {
-    }
     link_message(integer sender, integer num, string msg, key id)
     {
         if (num == 90208 || num == 90209)
@@ -163,7 +172,9 @@ state running
             product = llList2String(data, 2);
             llListenRemove(menu_handle);
             llListenRemove(GETSTATUShandle);
+            // FIXME: 2146483646 rounds up to 2147483648.0
             menu_handle = llListen(menu_channel = ((integer)llFrand(2147483646) + 1) * -1, "", CONTROLLER, "");
+            // FIXME: 999999999 rounds up to 1000000000.0
             GETSTATUShandle = llListen(RELAY_GETSTATUS_CHANNEL = (integer)llFrand(999999999), "", "", "");
             if (num == 90208)
             {
@@ -185,6 +196,7 @@ state running
             }
         }
     }
+
     listen(integer channel, string name, key id, string msg)
     {
         Out(1, "Listen Received: " + msg);
@@ -251,7 +263,7 @@ state running
             {
                 integer index = llListFindList(CLOTHING_LAYERS, [msg]);
                 command = "outfit";
-                if (!~index)
+                if (index == -1)
                 {
                     index = llListFindList(ATTACHMENT_POINTS, [msg]);
                     command = "attach";
@@ -353,7 +365,7 @@ state running
                             {
                                 icon = iconHalf;
                             }
-                            if (wornThis == 3 && wornSub == 0 || (wornThis == 0 && wornSub == 3) || (wornThis == 3 && wornSub == 3))
+                            if ((wornThis == 3 && wornSub == 0) || (wornThis == 0 && wornSub == 3) || (wornThis == 3 && wornSub == 3))
                             {
                                 icon = iconFull;
                             }
@@ -381,7 +393,7 @@ state running
                         msg = "Folder: /" + llDumpList2String(folderPath, "/") + "\n[" + icon + "]\n" + folderInfo;
                     }
                 }
-                if ((!llGetListLength(folderOptions)) && (!llGetListLength(BUTTONS)))
+                if (!llGetListLength(folderOptions) && !llGetListLength(BUTTONS))
                 {
                     msg = "#RLV folder empty";
                 }
@@ -407,7 +419,7 @@ state running
                     integer j;
                     while (j < llGetListLength(subRestrictions))
                     {
-                        if (!~llListFindList(currentRestrictions, [llList2String(subRestrictions, j)]))
+                        if (llListFindList(currentRestrictions, [llList2String(subRestrictions, j)]) == -1)
                         {
                             inActive = TRUE;
                         }

--- a/AVsitter2/Plugins/AVcontrol/[AV]root-RLV-extra.lsl
+++ b/AVsitter2/Plugins/AVcontrol/[AV]root-RLV-extra.lsl
@@ -172,10 +172,8 @@ state running
             product = llList2String(data, 2);
             llListenRemove(menu_handle);
             llListenRemove(GETSTATUShandle);
-            // FIXME: 2146483646 rounds up to 2147483648.0
-            menu_handle = llListen(menu_channel = ((integer)llFrand(2147483646) + 1) * -1, "", CONTROLLER, "");
-            // FIXME: 999999999 rounds up to 1000000000.0
-            GETSTATUShandle = llListen(RELAY_GETSTATUS_CHANNEL = (integer)llFrand(999999999), "", "", "");
+            menu_handle = llListen(menu_channel = ((integer)llFrand(0x7FFFFF80) + 1) * -1, "", CONTROLLER, ""); // 7FFFFF80 = max float < 2^31
+            GETSTATUShandle = llListen(RELAY_GETSTATUS_CHANNEL = (integer)llFrand(999999936), "", "", ""); // 999999936 = max float < 1e9
             if (num == 90208)
             {
                 main_menu();

--- a/AVsitter2/Plugins/AVcontrol/[AV]root-RLV-extra.lsl
+++ b/AVsitter2/Plugins/AVcontrol/[AV]root-RLV-extra.lsl
@@ -167,8 +167,8 @@ state running
         if (num == 90208 || num == 90209)
         {
             list data = llParseStringKeepNulls(id, ["|"], []);
-            SLAVE = (key)llList2String(data, 0);
-            CONTROLLER = (key)llList2String(data, 1);
+            SLAVE = llList2Key(data, 0);
+            CONTROLLER = llList2Key(data, 1);
             product = llList2String(data, 2);
             llListenRemove(menu_handle);
             llListenRemove(GETSTATUShandle);

--- a/AVsitter2/Plugins/AVcontrol/[AV]root-RLV.lsl
+++ b/AVsitter2/Plugins/AVcontrol/[AV]root-RLV.lsl
@@ -962,7 +962,7 @@ state running
                 integer index = llListFindList(DETECTED_AVATAR_SHORTNAMES, [msg]);
                 if (~index)
                 {
-                    if (llList2String(DETECTED_AVATAR_KEYS, index) == CONTROLLER)
+                    if (llList2Key(DETECTED_AVATAR_KEYS, index) == CONTROLLER)
                     {
                         info_dialog(CONTROLLER, "you can not capture yourself");
                     }

--- a/AVsitter2/Plugins/AVcontrol/[AV]root-RLV.lsl
+++ b/AVsitter2/Plugins/AVcontrol/[AV]root-RLV.lsl
@@ -358,8 +358,7 @@ new_controller(key id)
     CONTROLLER = id;
     controllerName = llKey2Name(CONTROLLER);
     llListenRemove(menu_handle);
-    // FIXME: 2147483646 rounds up to 2147483648.0
-    menu_handle = llListen(menu_channel = ((integer)llFrand(2147483646) + 1) * -1, "", CONTROLLER, "");
+    menu_handle = llListen(menu_channel = ((integer)llFrand(0x7FFFFF80) + 1) * -1, "", CONTROLLER, ""); // 7FFFFF80 = max float < 2^31
 }
 
 no_sensor_results()
@@ -375,12 +374,10 @@ no_sensor_results()
 
 get_unique_channels()
 {
-    // FIXME: 999999999 rounds up to 1000000000.0
-    RELAY_SEARCH_CHANNEL = (integer)llFrand(999999999) + 1;
+    RELAY_SEARCH_CHANNEL = (integer)llFrand(999999936) + 1; // 999999936 = max float < 1e9
     RELAY_GETCAPTURESTATUSchannel = RELAY_SEARCH_CHANNEL + 2;
     RELAY_CHECK_CHANNEL = RELAY_SEARCH_CHANNEL + 4;
-    // FIXME: 2146483646 rounds up to 2147483648.0
-    ASKROLE_CHANEL = ((integer)llFrand(2147483646) + 1) * -1;
+    ASKROLE_CHANEL = ((integer)llFrand(0x7FFFFF80) + 1) * -1; // 7FFFFF80 = max float < 2^31
     llListenRemove(relay_handle);
     relay_handle = llListen(RELAY_CHANNEL, "", "", ping = "ping," + (string)llGetKey() + ",ping,ping");
 }

--- a/AVsitter2/Plugins/AVcontrol/[AV]root-RLV.lsl
+++ b/AVsitter2/Plugins/AVcontrol/[AV]root-RLV.lsl
@@ -3,15 +3,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this 
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) the AVsitter Contributors (http://avsitter.github.io)
+ * Copyright © the AVsitter Contributors (http://avsitter.github.io)
  * AVsitter™ is a trademark. For trademark use policy see:
  * https://avsitter.github.io/TRADEMARK.mediawiki
- * 
+ *
  * Please consider supporting continued development of AVsitter and
  * receive automatic updates and other benefits! All details and user 
  * instructions can be found at http://avsitter.github.io
  */
- 
+
 string product = "AVsitter™ RLV";
 string version = "2.2";
 integer ignorenextswap;
@@ -72,6 +72,7 @@ integer subControl;
 string ping;
 integer captureOnAsk = TRUE;
 integer verbose = 0;
+
 Out(integer level, string out)
 {
     if (verbose >= level)
@@ -79,19 +80,23 @@ Out(integer level, string out)
         llOwnerSay(llGetScriptName() + "[" + version + "]:" + out);
     }
 }
+
 string strReplace(string str, string search, string replace)
 {
     return llDumpList2String(llParseStringKeepNulls(str, [search], []), replace);
 }
+
 list order_buttons(list buttons)
 {
     return llList2List(buttons, -3, -1) + llList2List(buttons, -6, -4) + llList2List(buttons, -9, -7) + llList2List(buttons, -12, -10);
 }
+
 relay(key av, string msg)
 {
     msg = "RLV," + (string)av + "," + msg;
     llSay(RELAY_CHANNEL, msg);
 }
+
 string humantime()
 {
     integer hours = TimelockSecUntilRelease / 3600;
@@ -119,6 +124,7 @@ string humantime()
     }
     return hours_text + minutes_text + seconds_text;
 }
+
 Timelock_menu()
 {
     menu = "Timelock";
@@ -150,6 +156,7 @@ Timelock_menu()
     }
     dialog(text, ["[BACK]", pauseButton, hidButton] + menu_items);
 }
+
 relay_select_menu()
 {
     menu = "SELECT";
@@ -173,6 +180,7 @@ relay_select_menu()
     }
     dialog(text, menu_items);
 }
+
 playpose(string pose, string target_sitter)
 {
     if (pose)
@@ -181,13 +189,14 @@ playpose(string pose, string target_sitter)
         llMessageLinked(LINK_SET, 90000, pose, target_sitter);
     }
 }
+
 rlv_top_menu()
 {
     menu = "";
     list menu_items;
     string text = "RLV for " + slaveName;
     list extra;
-    if (llGetListLength(SITTING_AVATARS) > 1 || (~llListFindList(DESIGNATIONS_NOW, ["S"])))
+    if (llGetListLength(SITTING_AVATARS) > 1 || ~llListFindList(DESIGNATIONS_NOW, ["S"]))
     {
         extra += "[BACK]";
     }
@@ -198,7 +207,7 @@ rlv_top_menu()
         {
             if (slaveWearingRelay)
             {
-                if ((~designationIndex) && llList2String(SITTER_DESIGNATIONS_MASTER, designationIndex) == "D")
+                if (~designationIndex && llList2String(SITTER_DESIGNATIONS_MASTER, designationIndex) == "D")
                 {
                     text = slaveName + " has not chosen submissive role.";
                 }
@@ -240,6 +249,7 @@ rlv_top_menu()
     }
     dialog(text, extra + menu_items);
 }
+
 capture_attempt(key id, string target_sitter)
 {
     if (RLV_ON)
@@ -258,10 +268,12 @@ capture_attempt(key id, string target_sitter)
         playpose(SUBPOSE, id);
     }
 }
+
 dialog(string text, list buttons)
 {
     llDialog(CONTROLLER, product + " " + version + "\n\n" + text, order_buttons(buttons), menu_channel);
 }
+
 reset()
 {
     CAPTIVES = [];
@@ -273,6 +285,7 @@ reset()
     TimelockSecUntilRelease = defaultTimelock;
     hovertext();
 }
+
 unsit_all()
 {
     integer i = llGetNumberOfPrims();
@@ -282,6 +295,7 @@ unsit_all()
         i--;
     }
 }
+
 release_all()
 {
     while (llGetListLength(CAPTIVES))
@@ -289,12 +303,14 @@ release_all()
         release(llList2Key(CAPTIVES, 1), FALSE);
     }
 }
+
 stop()
 {
     release_all();
     unsit_all();
     reset();
 }
+
 release(key SLAVE, integer allowUnsit)
 {
     integer index = llListFindList(CAPTIVES, [SLAVE]);
@@ -304,7 +320,7 @@ release(key SLAVE, integer allowUnsit)
         llSay(0, llKey2Name(SLAVE) + " was released.");
         relay(SLAVE, baseReleaseRestrictions);
         relay(SLAVE, "!release");
-        if (allowUnsit && (~llSubStringIndex(baseReleaseRestrictions, "@unsit=force")))
+        if (allowUnsit && ~llSubStringIndex(baseReleaseRestrictions, "@unsit=force"))
         {
             llUnSit(SLAVE);
         }
@@ -314,6 +330,7 @@ release(key SLAVE, integer allowUnsit)
         reset();
     }
 }
+
 start_relay_search()
 {
     DETECTED_AVATAR_KEYS = [];
@@ -324,6 +341,7 @@ start_relay_search()
     SEARCHhandle = llListen(RELAY_SEARCH_CHANNEL, "", "", "");
     llSetTimerEvent(1.5);
 }
+
 remove_script(string reason)
 {
     string message = "\n" + llGetScriptName() + " ==Script Removed==\n\n" + reason;
@@ -334,13 +352,16 @@ remove_script(string reason)
         llRemoveInventory(llGetScriptName());
     }
 }
+
 new_controller(key id)
 {
     CONTROLLER = id;
     controllerName = llKey2Name(CONTROLLER);
     llListenRemove(menu_handle);
+    // FIXME: 2147483646 rounds up to 2147483648.0
     menu_handle = llListen(menu_channel = ((integer)llFrand(2147483646) + 1) * -1, "", CONTROLLER, "");
 }
+
 no_sensor_results()
 {
     expecting_relay_results = FALSE;
@@ -351,15 +372,19 @@ no_sensor_results()
     }
     dialog("No avatars found in range!", menu_items);
 }
+
 get_unique_channels()
 {
+    // FIXME: 999999999 rounds up to 1000000000.0
     RELAY_SEARCH_CHANNEL = (integer)llFrand(999999999) + 1;
     RELAY_GETCAPTURESTATUSchannel = RELAY_SEARCH_CHANNEL + 2;
     RELAY_CHECK_CHANNEL = RELAY_SEARCH_CHANNEL + 4;
+    // FIXME: 2146483646 rounds up to 2147483648.0
     ASKROLE_CHANEL = ((integer)llFrand(2147483646) + 1) * -1;
     llListenRemove(relay_handle);
     relay_handle = llListen(RELAY_CHANNEL, "", "", ping = "ping," + (string)llGetKey() + ",ping,ping");
 }
+
 check_submissive()
 {
     relay(SLAVE, "@versionnew=" + (string)RELAY_CHECK_CHANNEL);
@@ -367,6 +392,7 @@ check_submissive()
     llSensorRepeat("", llGetOwner(), PASSIVE, 0.1, PI, 2);
     slaveName = llKey2Name(SLAVE);
 }
+
 select_submissive_rlv()
 {
     menu = "SUB_SELECT";
@@ -390,7 +416,7 @@ select_submissive_rlv()
     {
         text = "There are no submissives sitting.";
     }
-    if ((~llListFindList(DESIGNATIONS_NOW, ["S"])) && llGetListLength(SITTING_AVATARS) < llGetListLength(DESIGNATIONS_NOW))
+    if (~llListFindList(DESIGNATIONS_NOW, ["S"]) && llGetListLength(SITTING_AVATARS) < llGetListLength(DESIGNATIONS_NOW))
     {
         text += "\n\nCapture = trap a new avatar.";
         menu_items += "Capture...";
@@ -403,6 +429,7 @@ select_submissive_rlv()
     }
     dialog(text, menu_items);
 }
+
 find_seat(key id, integer index, string msg, integer captureSub)
 {
     if (~index)
@@ -466,10 +493,12 @@ find_seat(key id, integer index, string msg, integer captureSub)
         }
     }
 }
+
 info_dialog(key id, string text)
 {
     llDialog(id, product + " " + version + "\n\nSorry, " + text + ".\n", [], -7947386);
 }
+
 hovertext()
 {
     string text;
@@ -532,10 +561,12 @@ hovertext()
     }
     llMessageLinked(LINK_SET, 90014, llDumpList2String([CONTROLLER, llDumpList2String(CAPTIVES, ",")], "|"), "");
 }
+
 ask_role(key id)
 {
     llDialog(id, product + " " + version + "\n\nPlease select your role:\n", ["Dominant", "Submissive"], ASKROLE_CHANEL);
 }
+
 back(key id)
 {
     if (~llListFindList(SITTING_AVATARS, [id]))
@@ -547,6 +578,7 @@ back(key id)
         llMessageLinked(LINK_THIS, 90007, "", id);
     }
 }
+
 integer isSub(key id)
 {
     integer index = llListFindList(DESIGNATIONS_NOW, [id]);
@@ -560,6 +592,7 @@ integer isSub(key id)
     }
     return FALSE;
 }
+
 default
 {
     state_entry()
@@ -574,6 +607,7 @@ default
         }
     }
 }
+
 state running
 {
     state_entry()
@@ -587,6 +621,7 @@ state running
             notecard_query = llGetNotecardLine(notecard_name, 0);
         }
     }
+
     link_message(integer sender, integer num, string msg, key id)
     {
         if (num == 90030)
@@ -713,7 +748,7 @@ state running
                 integer isSittingIndex = llListFindList(SITTING_AVATARS, [id]);
                 if (~isSittingIndex)
                 {
-                    if (RLV_ON && (~designationIndex) && llList2String(SITTER_DESIGNATIONS_MASTER, designationIndex) == "S")
+                    if (RLV_ON && ~designationIndex && llList2String(SITTER_DESIGNATIONS_MASTER, designationIndex) == "S")
                     {
                         if (subControl)
                         {
@@ -805,6 +840,7 @@ state running
             }
         }
     }
+
     listen(integer channel, string name, key id, string msg)
     {
         if (channel == ASKROLE_CHANEL)
@@ -826,7 +862,7 @@ state running
                     TimelockSecUntilRelease = defaultTimelock;
                 }
                 llSay(0, newSlaveName + " was captured!");
-                if (!~llListFindList(CAPTIVES, [newSlave]))
+                if (llListFindList(CAPTIVES, [newSlave]) == -1)
                 {
                     CAPTIVES += [newSlaveName, newSlave];
                     if (llGetListLength(CAPTIVES) / 2 > llGetListLength(DESIGNATIONS_NOW))
@@ -884,7 +920,7 @@ state running
         else if (channel == RELAY_SEARCH_CHANNEL && expecting_relay_results)
         {
             key relay_owner = llGetOwnerKey(id);
-            if (!~llListFindList(DETECTED_AVATAR_KEYS, [relay_owner]))
+            if (llListFindList(DETECTED_AVATAR_KEYS, [relay_owner]) == -1)
             {
                 DETECTED_AVATAR_KEYS += relay_owner;
                 DETECTED_AVATAR_SHORTNAMES += llGetSubString(strReplace(llKey2Name(relay_owner), " Resident", ""), 0, 11);
@@ -981,12 +1017,12 @@ state running
                 }
                 else if (msg == "Stop" || msg == "Start")
                 {
-                    TimelockPaused = (!TimelockPaused);
+                    TimelockPaused = !TimelockPaused;
                     llSetTimerEvent(1);
                 }
                 else if (msg == "Hide" || msg == "Show")
                 {
-                    TimelockHidden = (!TimelockHidden);
+                    TimelockHidden = !TimelockHidden;
                 }
                 else
                 {
@@ -1033,7 +1069,7 @@ state running
                 llSetTimerEvent(0);
                 PairWhoStartedCapture = (string)CONTROLLER + (string)SLAVE;
                 integer index = llListFindList(SITTERS, [(string)SLAVE]);
-                if (!~index)
+                if (index == -1)
                 {
                     index = 0;
                 }
@@ -1048,6 +1084,7 @@ state running
             hovertext();
         }
     }
+
     no_sensor()
     {
         if (slaveWearingRelay)
@@ -1064,6 +1101,7 @@ state running
             no_sensor_results();
         }
     }
+
     sensor(integer total_number)
     {
         expected_number = total_number;
@@ -1078,6 +1116,7 @@ state running
             no_sensor_results();
         }
     }
+
     timer()
     {
         llSetTimerEvent(1);
@@ -1127,6 +1166,7 @@ state running
             relay_select_menu();
         }
     }
+
     changed(integer change)
     {
         if (change & CHANGED_LINK)
@@ -1157,6 +1197,7 @@ state running
             }
         }
     }
+
     dataserver(key query_id, string data)
     {
         if (query_id == notecard_query)
@@ -1226,7 +1267,7 @@ state running
                 }
                 else if (command == "TIMELOCK")
                 {
-                    defaultTimelock = (TimelockSecUntilRelease = (integer)part0 * 60);
+                    defaultTimelock = TimelockSecUntilRelease = (integer)part0 * 60;
                 }
                 else if (command == "ONCAPTURE")
                 {
@@ -1240,6 +1281,7 @@ state running
             }
         }
     }
+
     on_rez(integer start)
     {
         get_unique_channels();

--- a/AVsitter2/Plugins/AVcontrol/[AV]root-RLV.lsl
+++ b/AVsitter2/Plugins/AVcontrol/[AV]root-RLV.lsl
@@ -183,7 +183,7 @@ relay_select_menu()
 
 playpose(string pose, string target_sitter)
 {
-    if (pose)
+    if (pose != "")
     {
         llSleep(1);
         llMessageLinked(LINK_SET, 90000, pose, target_sitter);
@@ -289,7 +289,7 @@ reset()
 unsit_all()
 {
     integer i = llGetNumberOfPrims();
-    while (llGetAgentSize(llGetLinkKey(i)))
+    while (llGetAgentSize(llGetLinkKey(i)) != ZERO_VECTOR)
     {
         llUnSit(llGetLinkKey(i));
         i--;
@@ -401,7 +401,7 @@ select_submissive_rlv()
     {
         if (llList2String(SITTER_DESIGNATIONS_MASTER, i) == "S")
         {
-            if (llList2Key(DESIGNATIONS_NOW, i))
+            if (llList2Key(DESIGNATIONS_NOW, i)) // OSS::key k = llList2Key(DESIGNATIONS_NOW, i); if (osIsUUID(k) && k != NULL_KEY)
             {
                 menu_items += llGetSubString(strReplace(llKey2Name(llList2Key(DESIGNATIONS_NOW, i)), " Resident", ""), 0, 11);
                 SITTERS_MENUKEYS += llList2Key(DESIGNATIONS_NOW, i);
@@ -635,7 +635,7 @@ state running
                 {
                     release_all();
                 }
-                if (des1)
+                if (des1) // OSS::if (osIsUUID(des1) && des1 != NULL_KEY)
                 {
                     DESIGNATIONS_NOW = llListReplaceList(DESIGNATIONS_NOW, [des1], two, two);
                 }
@@ -643,7 +643,7 @@ state running
                 {
                     DESIGNATIONS_NOW = llListReplaceList(DESIGNATIONS_NOW, [role2], two, two);
                 }
-                if (des2)
+                if (des2) // OSS::if (osIsUUID(des2) && des2 != NULL_KEY)
                 {
                     DESIGNATIONS_NOW = llListReplaceList(DESIGNATIONS_NOW, [des2], one, one);
                 }
@@ -895,7 +895,7 @@ state running
                     {
                         if (~llListFindList(DESIGNATIONS_NOW, ["S"]))
                         {
-                            if (CONTROLLER)
+                            if (CONTROLLER) // OSS::if (osIsUUID(CONTROLLER) && CONTROLLER != NULL_KEY)
                             {
                                 PairWhoStartedCapture = (string)CONTROLLER + (string)llGetOwnerKey(id);
                             }
@@ -935,7 +935,7 @@ state running
             }
             else if (msg == "[BACK]")
             {
-                if (menu)
+                if (menu != "")
                 {
                     rlv_top_menu();
                 }

--- a/AVsitter2/Plugins/AVcontrol/[AV]root-RLV.lsl
+++ b/AVsitter2/Plugins/AVcontrol/[AV]root-RLV.lsl
@@ -627,8 +627,8 @@ state running
             {
                 integer one = (integer)msg;
                 integer two = (integer)((string)id);
-                key des1 = llList2String(DESIGNATIONS_NOW, one);
-                key des2 = llList2String(DESIGNATIONS_NOW, two);
+                key des1 = llList2Key(DESIGNATIONS_NOW, one);
+                key des2 = llList2Key(DESIGNATIONS_NOW, two);
                 string role1 = llList2String(SITTER_DESIGNATIONS_MASTER, one);
                 string role2 = llList2String(SITTER_DESIGNATIONS_MASTER, two);
                 if (role1 != role2)

--- a/AVsitter2/Plugins/AVcontrol/[AV]root-RLV.lsl
+++ b/AVsitter2/Plugins/AVcontrol/[AV]root-RLV.lsl
@@ -512,7 +512,7 @@ hovertext()
         for (i = 0; i < llGetListLength(CAPTIVES); i += 2)
         {
             string captiveName = llList2String(CAPTIVES, i);
-            key captiveUUID = (key)llList2String(CAPTIVES, i + 1);
+            key captiveUUID = llList2Key(CAPTIVES, i + 1);
             text += "\"" + captiveName + "\"\n";
         }
         if (TimelockSecUntilRelease)
@@ -815,12 +815,12 @@ state running
                     return;
                 }
                 new_controller(id);
-                if ((key)llList2String(data, 2) == id)
+                if (llList2Key(data, 2) == id)
                 {
                     select_submissive_rlv();
                     return;
                 }
-                SLAVE = (key)llList2String(data, 2);
+                SLAVE = llList2Key(data, 2);
                 check_submissive();
             }
         }

--- a/AVsitter2/Plugins/AVcontrol/[AV]root-control.lsl
+++ b/AVsitter2/Plugins/AVcontrol/[AV]root-control.lsl
@@ -3,15 +3,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this 
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) the AVsitter Contributors (http://avsitter.github.io)
+ * Copyright © the AVsitter Contributors (http://avsitter.github.io)
  * AVsitter™ is a trademark. For trademark use policy see:
  * https://avsitter.github.io/TRADEMARK.mediawiki
- * 
+ *
  * Please consider supporting continued development of AVsitter and
  * receive automatic updates and other benefits! All details and user 
  * instructions can be found at http://avsitter.github.io
  */
- 
+
 string product = "AVsitter™ Menu Control";
 string version = "2.2";
 string security_script = "[AV]root-security";
@@ -26,6 +26,7 @@ integer menu_channel;
 integer menu_handle;
 key key_request;
 integer verbose = 1;
+
 Out(integer level, string out)
 {
     if (verbose >= level)
@@ -33,14 +34,17 @@ Out(integer level, string out)
         llOwnerSay(llGetScriptName() + "[" + version + "]:" + out);
     }
 }
+
 list order_buttons(list buttons)
 {
     return llList2List(buttons, -3, -1) + llList2List(buttons, -6, -4) + llList2List(buttons, -9, -7) + llList2List(buttons, -12, -10);
 }
+
 string strReplace(string str, string search, string replace)
 {
     return llDumpList2String(llParseStringKeepNulls(str, [search], []), replace);
 }
+
 controller_menu(key id)
 {
     CONTROLLER = id;
@@ -104,13 +108,16 @@ controller_menu(key id)
         }
     }
 }
+
 dialog(string text, list menu_items, key id)
 {
     llListenRemove(menu_handle);
+    // FIXME: 2147483646 rounds up to 2147483648.0
     menu_handle = llListen(menu_channel = ((integer)llFrand(2147483646) + 1) * -1, "", id, "");
     llDialog(id, product + " " + version + "\n\n" + text + "\n", order_buttons(menu_items), menu_channel);
     llSetTimerEvent(120);
 }
+
 integer check_for_RLV()
 {
     if (llGetInventoryType(RLV_script) == INVENTORY_SCRIPT)
@@ -119,20 +126,24 @@ integer check_for_RLV()
     }
     return FALSE;
 }
+
 default
 {
     state_entry()
     {
         llSetTimerEvent(0);
     }
+
     on_rez(integer x)
     {
         llResetScript();
     }
+
     timer()
     {
         llListenRemove(menu_handle);
     }
+
     link_message(integer sender, integer num, string msg, key id)
     {
         if (num == 90007)
@@ -156,6 +167,7 @@ default
             DESIGNATIONS_NOW = llParseStringKeepNulls(msg, ["|"], []);
         }
     }
+
     listen(integer channel, string name, key id, string message)
     {
         llListenRemove(menu_handle);
@@ -185,6 +197,7 @@ default
             controller_menu(id);
         }
     }
+
     changed(integer change)
     {
         if (llGetAgentSize(llGetLinkKey(llGetNumberOfPrims())) == ZERO_VECTOR)

--- a/AVsitter2/Plugins/AVcontrol/[AV]root-control.lsl
+++ b/AVsitter2/Plugins/AVcontrol/[AV]root-control.lsl
@@ -112,8 +112,7 @@ controller_menu(key id)
 dialog(string text, list menu_items, key id)
 {
     llListenRemove(menu_handle);
-    // FIXME: 2147483646 rounds up to 2147483648.0
-    menu_handle = llListen(menu_channel = ((integer)llFrand(2147483646) + 1) * -1, "", id, "");
+    menu_handle = llListen(menu_channel = ((integer)llFrand(0x7FFFFF80) + 1) * -1, "", id, ""); // 7FFFFF80 = max float < 2^31
     llDialog(id, product + " " + version + "\n\n" + text + "\n", order_buttons(menu_items), menu_channel);
     llSetTimerEvent(120);
 }

--- a/AVsitter2/Plugins/AVcontrol/[AV]root-control.lsl
+++ b/AVsitter2/Plugins/AVcontrol/[AV]root-control.lsl
@@ -80,7 +80,7 @@ controller_menu(key id)
             integer i;
             for (i = 0; i < llGetListLength(SITTERS); i++)
             {
-                if (llList2Key(SITTERS, i) != NULL_KEY)
+                if (llList2String(SITTERS, i) != NULL_KEY)
                 {
                     menu_items += llGetSubString(strReplace(llKey2Name(llList2Key(SITTERS, i)), " Resident", ""), 0, 11);
                     SITTERS_MENUKEYS += llList2Key(SITTERS, i);

--- a/AVsitter2/Plugins/AVfaces/[AV]faces.lsl
+++ b/AVsitter2/Plugins/AVfaces/[AV]faces.lsl
@@ -40,8 +40,7 @@ integer IsInteger(string data)
     return llParseString2List((string)llParseString2List(data, ["8", "9"], []), ["0", "1", "2", "3", "4", "5", "6", "7"], []) == [] && data != "";
 }
 
-// FIXME: make this 2.2
-string version = "2.1";
+string version = "2.2";
 string notecard_name = "AVpos";
 string main_script = "[AV]sitA";
 key key_request;
@@ -113,10 +112,9 @@ start_sequence(integer sequence_index, key av)
     {
         if (llList2Key(running_uuid, wasRunning) == av)
         {
-            // FIXME: use llDeleteSubList
-            running_uuid = llListReplaceList(running_uuid, [], wasRunning, wasRunning);
-            running_sequence_indexes = llListReplaceList(running_sequence_indexes, [], wasRunning, wasRunning);
-            running_pointers = llListReplaceList(running_pointers, [], wasRunning, wasRunning);
+            running_uuid = llDeleteSubList(running_uuid, wasRunning, wasRunning);
+            running_sequence_indexes = llDeleteSubList(running_sequence_indexes, wasRunning, wasRunning);
+            running_pointers = llDeleteSubList(running_pointers, wasRunning, wasRunning);
         }
     }
     running_uuid += av;
@@ -367,15 +365,17 @@ default
         {
             if (llGetInventoryKey(notecard_name) != notecard_key)
             {
-                llResetScript();
+                llResetScript(); // llResetScript() never returns
             }
-            else if (get_number_of_scripts() != llGetListLength(SITTERS))
+            if (get_number_of_scripts() != llGetListLength(SITTERS))
             {
                 init_sitters();
             }
         }
         /*
-        else if (change & CHANGED_LINK) // FIXME: remove 'else'
+        // If you uncomment this, don't make this an 'else if', as
+        // changed events may come several at a time.
+        if (change & CHANGED_LINK)
         {
             if (llGetAgentSize(llGetLinkKey(llGetNumberOfPrims())) == ZERO_VECTOR)
             {

--- a/AVsitter2/Plugins/AVfaces/[AV]faces.lsl
+++ b/AVsitter2/Plugins/AVfaces/[AV]faces.lsl
@@ -155,7 +155,7 @@ sequence()
             {
                 anim = llStringTrim(llList2String(sequence_anims, j - 1), STRING_TRIM);
             }
-            if (anim)
+            if (anim != "")
             {
                 if (IsInteger(anim))
                 {
@@ -204,7 +204,7 @@ remove_sequences(key id)
         list sequence = llParseStringKeepNulls(llList2String(anim_animsequences, llList2Integer(running_sequence_indexes, index)), ["|"], []);
         running_sequence_indexes = llDeleteSubList(running_sequence_indexes, index, index);
         running_pointers = llDeleteSubList(running_pointers, index, index);
-        while (sequence)
+        while (sequence != [])
         {
             if (!IsInteger(llList2String(sequence, 0)) && llList2String(sequence, 0) != "none")
             {

--- a/AVsitter2/Plugins/AVfaces/[AV]faces.lsl
+++ b/AVsitter2/Plugins/AVfaces/[AV]faces.lsl
@@ -3,21 +3,44 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this 
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) the AVsitter Contributors (http://avsitter.github.io)
+ * Copyright © the AVsitter Contributors (http://avsitter.github.io)
  * AVsitter™ is a trademark. For trademark use policy see:
  * https://avsitter.github.io/TRADEMARK.mediawiki
- * 
+ *
  * Please consider supporting continued development of AVsitter and
  * receive automatic updates and other benefits! All details and user 
  * instructions can be found at http://avsitter.github.io
  */
- 
+
 integer is_running = TRUE;
-list facial_anim_list = ["express_afraid_emote", "express_anger_emote", "express_laugh_emote", "express_bored_emote", "express_cry_emote", "express_embarrassed_emote", "express_sad_emote", "express_toothsmile", "express_smile", "express_surprise_emote", "express_worry_emote", "express_repulsed_emote", "express_shrug_emote", "express_wink_emote", "express_disdain", "express_frown", "express_kiss", "express_open_mouth", "express_tongue_out"];
+list facial_anim_list =
+    [ "express_afraid_emote"
+    , "express_anger_emote"
+    , "express_laugh_emote"
+    , "express_bored_emote"
+    , "express_cry_emote"
+    , "express_embarrassed_emote"
+    , "express_sad_emote"
+    , "express_toothsmile"
+    , "express_smile"
+    , "express_surprise_emote"
+    , "express_worry_emote"
+    , "express_repulsed_emote"
+    , "express_shrug_emote"
+    , "express_wink_emote"
+    , "express_disdain"
+    , "express_frown"
+    , "express_kiss"
+    , "express_open_mouth"
+    , "express_tongue_out"
+    ];
+
 integer IsInteger(string data)
 {
     return llParseString2List((string)llParseString2List(data, ["8", "9"], []), ["0", "1", "2", "3", "4", "5", "6", "7"], []) == [] && data != "";
 }
+
+// FIXME: make this 2.2
 string version = "2.1";
 string notecard_name = "AVpos";
 string main_script = "[AV]sitA";
@@ -34,6 +57,7 @@ list running_sequence_indexes;
 list running_pointers;
 list SITTERS;
 list SITTER_POSES;
+
 integer get_number_of_scripts()
 {
     integer i = 1;
@@ -43,7 +67,9 @@ integer get_number_of_scripts()
     }
     return i;
 }
+
 integer verbose = 0;
+
 Out(integer level, string out)
 {
     if (verbose >= level)
@@ -51,15 +77,18 @@ Out(integer level, string out)
         llOwnerSay(llGetScriptName() + "[" + version + "] " + out);
     }
 }
+
 Readout_Say(string say, string SCRIPT_CHANNEL)
 {
     llSleep(0.2);
     llMessageLinked(LINK_THIS, 90022, say, SCRIPT_CHANNEL);
 }
+
 string Key2Number(key objKey)
 {
     return llGetSubString((string)llAbs((integer)("0x" + llGetSubString((string)objKey, -8, -1)) & 1073741823 ^ -1073741825), 6, -1);
 }
+
 init_sitters()
 {
     SITTERS = [];
@@ -71,10 +100,12 @@ init_sitters()
         SITTER_POSES += "";
     }
 }
+
 string element(string text, integer x)
 {
     return llList2String(llParseStringKeepNulls(text, ["|"], []), x);
 }
+
 start_sequence(integer sequence_index, key av)
 {
     integer wasRunning = llListFindList(running_sequence_indexes, [sequence_index]);
@@ -82,6 +113,7 @@ start_sequence(integer sequence_index, key av)
     {
         if (llList2Key(running_uuid, wasRunning) == av)
         {
+            // FIXME: use llDeleteSubList
             running_uuid = llListReplaceList(running_uuid, [], wasRunning, wasRunning);
             running_sequence_indexes = llListReplaceList(running_sequence_indexes, [], wasRunning, wasRunning);
             running_pointers = llListReplaceList(running_pointers, [], wasRunning, wasRunning);
@@ -92,6 +124,7 @@ start_sequence(integer sequence_index, key av)
     running_pointers += 0;
     llSetTimerEvent(0.01);
 }
+
 sequence()
 {
     list anims;
@@ -162,6 +195,7 @@ sequence()
         }
     }
 }
+
 remove_sequences(key id)
 {
     integer index;
@@ -174,7 +208,7 @@ remove_sequences(key id)
         running_pointers = llDeleteSubList(running_pointers, index, index);
         while (sequence)
         {
-            if ((!IsInteger(llList2String(sequence, 0))) && llList2String(sequence, 0) != "none")
+            if (!IsInteger(llList2String(sequence, 0)) && llList2String(sequence, 0) != "none")
             {
                 llMessageLinked(LINK_THIS, 90002, llList2String(sequence, 0), id);
             }
@@ -186,6 +220,7 @@ remove_sequences(key id)
         llSetTimerEvent(0);
     }
 }
+
 default
 {
     state_entry()
@@ -198,15 +233,18 @@ default
             notecard_query = llGetNotecardLine(notecard_name, 0);
         }
     }
+
     timer()
     {
         sequence();
         llSetTimerEvent(1);
     }
+
     on_rez(integer start)
     {
         is_running = TRUE;
     }
+
     link_message(integer sender, integer num, string msg, key id)
     {
         if (num == 90100)
@@ -247,7 +285,7 @@ default
                         if (llList2String(anim_triggers, i) == given_posename)
                         {
                             integer reference = llListFindList(anim_triggers, [(string)sitter + "|" + llList2String(anim_animsequences, i)]);
-                            if (!~reference)
+                            if (reference == -1)
                             {
                                 reference = i;
                             }
@@ -303,7 +341,7 @@ default
                 integer i;
                 for (i = 0; i < llGetListLength(anim_triggers); i++)
                 {
-                    if (!llSubStringIndex(llList2String(anim_triggers, i), msg + "|"))
+                    if (llSubStringIndex(llList2String(anim_triggers, i), msg + "|") == 0)
                     {
                         list trigger = llParseString2List(llList2String(anim_triggers, i), ["|"], []);
                         list sequence = llParseString2List(llList2String(anim_animsequences, i), ["|"], []);
@@ -322,6 +360,7 @@ default
             }
         }
     }
+
     changed(integer change)
     {
         if (change & CHANGED_INVENTORY)
@@ -335,13 +374,16 @@ default
                 init_sitters();
             }
         }
-        else if (change & CHANGED_LINK)
+        /*
+        else if (change & CHANGED_LINK) // FIXME: remove 'else'
         {
             if (llGetAgentSize(llGetLinkKey(llGetNumberOfPrims())) == ZERO_VECTOR)
             {
             }
         }
+        */
     }
+
     dataserver(key query_id, string data)
     {
         if (query_id == notecard_query)

--- a/AVsitter2/Plugins/AVfaces/[AV]faces.lsl
+++ b/AVsitter2/Plugins/AVfaces/[AV]faces.lsl
@@ -139,7 +139,7 @@ sequence()
         integer j;
         while (j <= llGetListLength(sequence_durations))
         {
-            integer lastDuration = (integer)llList2String(sequence_durations, j - 1);
+            integer lastDuration = llList2Integer(sequence_durations, j - 1);
             integer repeats = FALSE;
             if (lastDuration < 0)
             {
@@ -169,7 +169,7 @@ sequence()
                 sequence_pointer++;
                 jump go;
             }
-            integer duration = llAbs((integer)llList2String(sequence_durations, j));
+            integer duration = llAbs(llList2Integer(sequence_durations, j));
             sequence_length += duration;
             j++;
         }
@@ -270,7 +270,7 @@ default
             if (num == 90045)
             {
                 list data = llParseStringKeepNulls(msg, ["|"], []);
-                integer sitter = (integer)llList2String(data, 0);
+                integer sitter = llList2Integer(data, 0);
                 if (id == llList2Key(SITTERS, sitter))
                 {
                     string given_posename = llList2String(data, 1);
@@ -348,7 +348,7 @@ default
                         {
                             if (IsInteger(llList2String(sequence, x)))
                             {
-                                sequence = llListReplaceList(sequence, [llList2String(facial_anim_list, (integer)llList2String(sequence, x))], x, x);
+                                sequence = llListReplaceList(sequence, [llList2String(facial_anim_list, llList2Integer(sequence, x))], x, x);
                             }
                         }
                         Readout_Say("ANIM " + llList2String(trigger, 1) + "|" + llDumpList2String(sequence, "|"), msg);

--- a/AVsitter2/Plugins/AVfaces/[AV]faces.lsl
+++ b/AVsitter2/Plugins/AVfaces/[AV]faces.lsl
@@ -250,7 +250,7 @@ default
             list data = llParseString2List(msg, ["|"], []);
             if (llList2String(data, 1) == "[FACES]")
             {
-                llMessageLinked(sender, 90101, llDumpList2String([llList2String(data, 0), "[ADJUST]", id], "|"), llList2String(data, 2));
+                llMessageLinked(sender, 90101, llDumpList2String([llList2String(data, 0), "[ADJUST]", id], "|"), llList2Key(data, 2));
                 if (id == llGetOwner())
                 {
                     is_running = (!is_running);

--- a/AVsitter2/Plugins/AVprop/[AV]menu.lsl
+++ b/AVsitter2/Plugins/AVprop/[AV]menu.lsl
@@ -323,7 +323,7 @@ default
 
     listen(integer listen_channel, string name, key id, string msg)
     {
-        if (choice)
+        if (choice != "")
         {
             if (msg == "")
             {
@@ -376,11 +376,11 @@ default
         if (mindex_test != -1)
         {
             list button_data = llParseStringKeepNulls(llList2String(DATA_LIST, mindex_test), ["�"], []);
-            if (llList2String(button_data, 1))
+            if (llList2String(button_data, 1) != "")
             {
                 msg = llList2String(button_data, 1);
             }
-            if (llList2String(button_data, 2))
+            if (llList2String(button_data, 2) != "")
             {
                 id = llList2String(button_data, 2);
             }
@@ -447,7 +447,7 @@ default
             Readout_Say("");
             Readout_Say("--✄--COPY BELOW INTO \"AVpos\" NOTECARD--✄--");
             Readout_Say("");
-            if (custom_text)
+            if (custom_text != "")
             {
                 Readout_Say("TEXT " + strReplace(custom_text, "\n", "\\n"));
             }

--- a/AVsitter2/Plugins/AVprop/[AV]menu.lsl
+++ b/AVsitter2/Plugins/AVprop/[AV]menu.lsl
@@ -384,7 +384,7 @@ default
             {
                 id = llList2String(button_data, 2);
             }
-            llMessageLinked(LINK_SET, (integer)llList2String(button_data, 0), msg, id);
+            llMessageLinked(LINK_SET, llList2Integer(button_data, 0), msg, id);
             return;
         }
         else if (msg == "[>>]" || msg == "[<<]")

--- a/AVsitter2/Plugins/AVprop/[AV]menu.lsl
+++ b/AVsitter2/Plugins/AVprop/[AV]menu.lsl
@@ -382,7 +382,7 @@ default
             }
             if (llList2String(button_data, 2) != "")
             {
-                id = llList2String(button_data, 2);
+                id = llList2Key(button_data, 2);
             }
             llMessageLinked(LINK_SET, llList2Integer(button_data, 0), msg, id);
             return;

--- a/AVsitter2/Plugins/AVprop/[AV]menu.lsl
+++ b/AVsitter2/Plugins/AVprop/[AV]menu.lsl
@@ -3,15 +3,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this 
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) the AVsitter Contributors (http://avsitter.github.io)
+ * Copyright © the AVsitter Contributors (http://avsitter.github.io)
  * AVsitter™ is a trademark. For trademark use policy see:
  * https://avsitter.github.io/TRADEMARK.mediawiki
- * 
+ *
  * Please consider supporting continued development of AVsitter and
  * receive automatic updates and other benefits! All details and user 
  * instructions can be found at http://avsitter.github.io
  */
- 
+
 string product = "AVmenu™";
 string version = "2.2";
 integer verbose = 0;
@@ -285,6 +285,7 @@ integer prop_menu(integer return_pages, key av)
         menu_items1 = ["[BACK]"] + menu_items1;
         menu_items2 = llDeleteSubList(menu_items2, 0, 0);
     }
+    // FIXME: 2147483646 rounds up to 2147483648.0
     menu_channel = ((integer)llFrand(2147483646) + 1) * -1;
     llListenRemove(listen_handle);
     listen_handle = llListen(menu_channel, "", av, "");
@@ -294,7 +295,7 @@ integer prop_menu(integer return_pages, key av)
 
 string strReplace(string str, string search, string replace)
 {
-    return llDumpList2String(llParseStringKeepNulls((str = "") + str, [search], []), replace);
+    return llDumpList2String(llParseStringKeepNulls(str, [search], []), replace);
 }
 
 naming()

--- a/AVsitter2/Plugins/AVprop/[AV]menu.lsl
+++ b/AVsitter2/Plugins/AVprop/[AV]menu.lsl
@@ -285,8 +285,7 @@ integer prop_menu(integer return_pages, key av)
         menu_items1 = ["[BACK]"] + menu_items1;
         menu_items2 = llDeleteSubList(menu_items2, 0, 0);
     }
-    // FIXME: 2147483646 rounds up to 2147483648.0
-    menu_channel = ((integer)llFrand(2147483646) + 1) * -1;
+    menu_channel = ((integer)llFrand(0x7FFFFF80) + 1) * -1; // 7FFFFF80 = max float < 2^31
     llListenRemove(listen_handle);
     listen_handle = llListen(menu_channel, "", av, "");
     dialog(av, custom_text, menu_items1 + menu_items2);

--- a/AVsitter2/Plugins/AVprop/[AV]object.lsl
+++ b/AVsitter2/Plugins/AVprop/[AV]object.lsl
@@ -26,7 +26,7 @@ key give_prop_warning_request;
 unsit_all()
 {
     integer i = llGetNumberOfPrims();
-    while (llGetAgentSize(llGetLinkKey(i)))
+    while (llGetAgentSize(llGetLinkKey(i)) != ZERO_VECTOR)
     {
         llUnSit(llGetLinkKey(i));
         i--;
@@ -216,7 +216,7 @@ state prop
                 }
                 else
                 {
-                    if (llGetAgentSize(llGetLinkKey(llGetNumberOfPrims())))
+                    if (llGetAgentSize(llGetLinkKey(llGetNumberOfPrims())) != ZERO_VECTOR)
                     {
                         unsit_all();
                         llSleep(1);

--- a/AVsitter2/Plugins/AVprop/[AV]object.lsl
+++ b/AVsitter2/Plugins/AVprop/[AV]object.lsl
@@ -3,10 +3,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this 
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) the AVsitter Contributors (http://avsitter.github.io)
+ * Copyright © the AVsitter Contributors (http://avsitter.github.io)
  * AVsitter™ is a trademark. For trademark use policy see:
  * https://avsitter.github.io/TRADEMARK.mediawiki
- * 
+ *
  * Please consider supporting continued development of AVsitter and
  * receive automatic updates and other benefits! All details and user 
  * instructions can be found at http://avsitter.github.io
@@ -45,10 +45,6 @@ Out(integer level, string out)
 
 default
 {
-    state_entry()
-    {
-    }
-
     on_rez(integer start)
     {
         if (start)
@@ -121,7 +117,7 @@ state prop
 
     touch_start(integer touched)
     {
-        if ((!llGetAttached()) && (prop_type == 2 || prop_type == 1))
+        if (!llGetAttached() && (prop_type == 2 || prop_type == 1))
         {
             llRequestExperiencePermissions(llDetectedKey(0), "");
         }
@@ -201,7 +197,7 @@ state prop
             {
                 remove = TRUE;
             }
-            else if (command == "REM_INDEX" || (command == "REM_WORLD" && (!llGetAttached())))
+            else if (command == "REM_INDEX" || (command == "REM_WORLD" && !llGetAttached()))
             {
                 if (~llListFindList(data, [(string)prop_id]))
                 {
@@ -230,7 +226,7 @@ state prop
                 }
             }
         }
-        else if (message == "PROPSEARCH" && (!llGetAttached()))
+        else if (message == "PROPSEARCH" && !llGetAttached())
         {
             llSay(comm_channel, "SAVEPROP|" + (string)prop_id);
         }

--- a/AVsitter2/Plugins/AVprop/[AV]object.lsl
+++ b/AVsitter2/Plugins/AVprop/[AV]object.lsl
@@ -178,16 +178,16 @@ state prop
         {
             llRequestPermissions(llGetOwner(), PERMISSION_ATTACH);
         }
-        else if (command == "ATTACHTO" && prop_type == 1 && (key)llList2String(data, 2) == llGetKey())
+        else if (command == "ATTACHTO" && prop_type == 1 && llList2Key(data, 2) == llGetKey())
         {
-            if (llGetAgentSize((key)llList2String(data, 1)) == ZERO_VECTOR)
+            if (llGetAgentSize(llList2Key(data, 1)) == ZERO_VECTOR)
             {
                 llSay(comm_channel, "DEREZ|" + (string)prop_id);
                 llDie();
             }
             else
             {
-                llRequestExperiencePermissions((key)llList2String(data, 1), "");
+                llRequestExperiencePermissions(llList2Key(data, 1), "");
             }
         }
         else if (llGetSubString(command, 0, 3) == "REM_")
@@ -204,7 +204,7 @@ state prop
                     remove = TRUE;
                 }
             }
-            else if (llGetAttached() && command == "REM_WORN" && (key)llList2String(data, 1) == llGetOwner())
+            else if (llGetAttached() && command == "REM_WORN" && llList2Key(data, 1) == llGetOwner())
             {
                 remove = TRUE;
             }

--- a/AVsitter2/Plugins/AVprop/[AV]prop.lsl
+++ b/AVsitter2/Plugins/AVprop/[AV]prop.lsl
@@ -349,7 +349,7 @@ default
             if (num == 90045) // play pose
             {
                 list data = llParseStringKeepNulls(msg, ["|"], []);
-                integer sitter = (integer)llList2String(data, 0);
+                integer sitter = llList2Integer(data, 0);
                 if (id == llList2Key(SITTERS, sitter))
                 {
                     remove_sitter_props_by_pose(llList2String(SITTER_POSES, sitter), FALSE);
@@ -363,7 +363,7 @@ default
             else if (num == 90200 || num == 90220) // rez or clear prop with/without sending menu back
             {
                 list ids = llParseStringKeepNulls(id, ["|"], []);
-                key sitting_av_or_sitter = (key)llList2String(ids, -1);
+                key sitting_av_or_sitter = llList2Key(ids, -1);
                 if (llGetInventoryType(main_script) != INVENTORY_SCRIPT)
                 {
                     SITTERS = [sitting_av_or_sitter];
@@ -537,7 +537,7 @@ default
         list data = llParseStringKeepNulls(message, ["|"], []);
         if (llList2String(data, 0) == "SAVEPROP")
         {
-            integer index = (integer)llList2String(data, 1);
+            integer index = llList2Integer(data, 1);
             if (index >= 0 && index < llGetListLength(prop_triggers))
             {
                 if (llList2Vector(llGetObjectDetails(id, [OBJECT_POS]), 0) != ZERO_VECTOR)
@@ -564,8 +564,8 @@ default
         }
         else if (llList2String(data, 0) == "ATTACHED" || llList2String(data, 0) == "DETACHED" || llList2String(data, 0) == "REZ" || llList2String(data, 0) == "DEREZ")
         {
-            integer prop_index = (integer)llList2String(data, 1);
-            integer sitter = (integer)llList2String(llParseStringKeepNulls(llList2String(prop_triggers, prop_index), ["|"], []), 0);
+            integer prop_index = llList2Integer(data, 1);
+            integer sitter = llList2Integer(llParseStringKeepNulls(llList2String(prop_triggers, prop_index), ["|"], []), 0);
             key sitter_key = llList2Key(SITTERS, sitter);
             if (sitter_key != NULL_KEY && llList2String(data, 0) == "REZ" && llList2Integer(prop_types, prop_index) == 1)
             {
@@ -597,7 +597,7 @@ default
                 list parts = llParseStringKeepNulls(llGetSubString(data, llSubStringIndex(data, " ") + 1, -1), [" | ", " |", "| ", "|"], []);
                 if (command == "SITTER")
                 {
-                    notecard_section = (integer)llList2String(parts, 0);
+                    notecard_section = llList2Integer(parts, 0);
                 }
                 else if (llGetSubString(command, 0, 3) == "PROP")
                 {
@@ -636,7 +636,7 @@ default
                 }
                 else if (command == "WARN")
                 {
-                    WARN = (integer)llList2String(parts, 0);
+                    WARN = llList2Integer(parts, 0);
                 }
                 notecard_query = llGetNotecardLine(notecard_name, notecard_line += 1);
             }

--- a/AVsitter2/Plugins/AVprop/[AV]prop.lsl
+++ b/AVsitter2/Plugins/AVprop/[AV]prop.lsl
@@ -492,7 +492,7 @@ default
                 {
                     if (llSubStringIndex(llList2String(prop_triggers, i), msg + "|") == 0)
                     {
-                        string type = (string)llList2Integer(prop_types, i);
+                        string type = llList2String(prop_types, i);
                         if (type == "0")
                         {
                             type = "";

--- a/AVsitter2/Plugins/AVprop/[AV]prop.lsl
+++ b/AVsitter2/Plugins/AVprop/[AV]prop.lsl
@@ -519,7 +519,7 @@ default
                 init_sitters();
             }
         }
-        else if (change & CHANGED_LINK)
+        if (change & CHANGED_LINK)
         {
             if (llGetAgentSize(llGetLinkKey(llGetNumberOfPrims())) == ZERO_VECTOR)
             {

--- a/AVsitter2/Plugins/AVprop/[AV]prop.lsl
+++ b/AVsitter2/Plugins/AVprop/[AV]prop.lsl
@@ -223,7 +223,7 @@ remove_props_by_sitter(string sitter, integer remove_type3)
     {
         command = "REM_WORLD";
     }
-    if (text)
+    if (text != [])
     {
         send_command(llDumpList2String([command] + text, "|"));
     }
@@ -248,7 +248,7 @@ remove_sitter_props_by_pose(string sitter_pose, integer remove_type3)
             }
         }
     }
-    if (text)
+    if (text != [])
     {
         send_command(llDumpList2String(["REM_INDEX"] + text, "|"));
     }
@@ -286,7 +286,7 @@ remove_props_by_group(integer gp)
     {
         command = "REM_WORLD";
     }
-    if (text)
+    if (text != [])
     {
         send_command(llDumpList2String([command] + text, "|"));
     }
@@ -413,7 +413,7 @@ default
                         }
                     }
                 }
-                if (sitting_av_or_sitter)
+                if (sitting_av_or_sitter) // OSS::if (osIsUUID(sitting_av_or_sitter) && sitting_av_or_sitter != NULL_KEY)
                 {
                     if (num == 90200) // send menu back?
                     {

--- a/AVsitter2/Plugins/AVprop/[AV]prop.lsl
+++ b/AVsitter2/Plugins/AVprop/[AV]prop.lsl
@@ -3,15 +3,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this 
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) the AVsitter Contributors (http://avsitter.github.io)
+ * Copyright © the AVsitter Contributors (http://avsitter.github.io)
  * AVsitter™ is a trademark. For trademark use policy see:
  * https://avsitter.github.io/TRADEMARK.mediawiki
- * 
+ *
  * Please consider supporting continued development of AVsitter and
  * receive automatic updates and other benefits! All details and user 
  * instructions can be found at http://avsitter.github.io
  */
- 
+
 string version = "2.2";
 string notecard_name = "AVpos";
 string main_script = "[AV]sitA";

--- a/AVsitter2/Plugins/AVsequence/[AV]sequence.lsl
+++ b/AVsitter2/Plugins/AVsequence/[AV]sequence.lsl
@@ -275,7 +275,7 @@ default
                 }
                 else if (command == "SEQUENCE")
                 {
-                    if (CURRENT_SEQUENCE_NAME)
+                    if (CURRENT_SEQUENCE_NAME != "")
                     {
                         commit_sequence_data();
                     }

--- a/AVsitter2/Plugins/AVsequence/[AV]sequence.lsl
+++ b/AVsitter2/Plugins/AVsequence/[AV]sequence.lsl
@@ -3,15 +3,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this 
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) the AVsitter Contributors (http://avsitter.github.io)
+ * Copyright © the AVsitter Contributors (http://avsitter.github.io)
  * AVsitter™ is a trademark. For trademark use policy see:
  * https://avsitter.github.io/TRADEMARK.mediawiki
- * 
+ *
  * Please consider supporting continued development of AVsitter and
  * receive automatic updates and other benefits! All details and user 
  * instructions can be found at http://avsitter.github.io
  */
- 
+
 string product = "AVsitter™ sequence";
 string version = "2.2";
 string main_script = "[AV]sitA";
@@ -37,6 +37,7 @@ integer menu_handle;
 integer playsounds = TRUE;
 integer no_waits_yet;
 integer verbose = 1;
+
 Out(integer level, string out)
 {
     if (verbose >= level)
@@ -44,10 +45,12 @@ Out(integer level, string out)
         llOwnerSay(llGetScriptName() + "[" + version + "] " + out);
     }
 }
+
 string strReplace(string str, string search, string replace)
 {
     return llDumpList2String(llParseStringKeepNulls(str, [search], []), replace);
 }
+
 DEBUGSay(integer level, string out)
 {
     if (DEBUG >= level)
@@ -55,6 +58,7 @@ DEBUGSay(integer level, string out)
         llWhisper(0, out);
     }
 }
+
 run_sequence()
 {
     while (SEQUENCE_POINTER >= 0)
@@ -152,6 +156,7 @@ run_sequence()
         }
     }
 }
+
 integer get_number_of_scripts()
 {
     integer i;
@@ -159,6 +164,7 @@ integer get_number_of_scripts()
         ;
     return i;
 }
+
 string parse_text(string say)
 {
     integer i;
@@ -173,15 +179,17 @@ string parse_text(string say)
     }
     return say;
 }
+
 start_sequence(integer index)
 {
-    no_waits_yet = (sequence_running = TRUE);
+    no_waits_yet = sequence_running = TRUE;
     SEQUENCE_POINTER = 0;
     CURRENT_SEQUENCE_NAME = llList2String(SEQUENCE_DATA_NAMES, index);
     CURRENT_SEQUENCE_ACTIONS = llParseStringKeepNulls(llList2String(SEQUENCE_DATA_ACTIONS, index), ["◆"], []);
     CURRENT_SEQUENCE_DATAS = llParseStringKeepNulls(llList2String(SEQUENCE_DATA_DATAS, index), ["◆"], []);
     DEBUGSay(1, "Sequence '" + CURRENT_SEQUENCE_NAME + "' Started!");
 }
+
 stop_sequence(integer stopSound)
 {
     if (sequence_running)
@@ -191,14 +199,16 @@ stop_sequence(integer stopSound)
     sequence_running = FALSE;
     SEQUENCE_POINTER = -1;
     llSetTimerEvent(0);
-    if (stopSound && (~llListFindList(CURRENT_SEQUENCE_ACTIONS, ["SOUND"])))
+    if (stopSound && ~llListFindList(CURRENT_SEQUENCE_ACTIONS, ["SOUND"]))
     {
         llStopSound();
     }
 }
+
 sequence_control()
 {
     llListenRemove(menu_handle);
+    // FIXME: float rounds up to 2147483648.0
     menu_channel = ((integer)llFrand(2147483646) + 1) * -1;
     string pauseplay = "▶";
     if (sequence_running)
@@ -209,16 +219,19 @@ sequence_control()
     menu_handle = llListen(menu_channel, "", CONTROLLER, "");
     llDialog(CONTROLLER, product + " " + version + "\n\n[" + CURRENT_SEQUENCE_NAME + "]\n◀◀ = previous anim in sequence.\n▮▮ = pause sequence.\n▶▶ = skip to next anim in sequence.", order_buttons(["[BACK]"] + menu_items), menu_channel);
 }
+
 list order_buttons(list buttons)
 {
     return llList2List(buttons, -3, -1) + llList2List(buttons, -6, -4) + llList2List(buttons, -9, -7) + llList2List(buttons, -12, -10);
 }
+
 commit_sequence_data()
 {
     SEQUENCE_DATA_NAMES += CURRENT_SEQUENCE_NAME;
     SEQUENCE_DATA_ACTIONS += llDumpList2String(CURRENT_SEQUENCE_ACTIONS, "◆");
     SEQUENCE_DATA_DATAS += llDumpList2String(CURRENT_SEQUENCE_DATAS, "◆");
 }
+
 default
 {
     state_entry()
@@ -230,6 +243,7 @@ default
             notecard_query = llGetNotecardLine(notecard_name, notecard_line);
         }
     }
+
     changed(integer change)
     {
         if (change & CHANGED_INVENTORY)
@@ -240,6 +254,7 @@ default
             }
         }
     }
+
     dataserver(key query_id, string data)
     {
         if (query_id == notecard_query)
@@ -279,6 +294,7 @@ default
         }
     }
 }
+
 state running
 {
     state_entry()
@@ -290,6 +306,7 @@ state running
             SITTERS += NULL_KEY;
         }
     }
+
     link_message(integer sender, integer num, string msg, key id)
     {
         if (sender == llGetLinkNumber())
@@ -326,7 +343,7 @@ state running
             else if (num == 90205)
             {
                 llMessageLinked(LINK_SET, 90005, "", id);
-                playsounds = (!playsounds);
+                playsounds = !playsounds;
                 if (playsounds)
                 {
                     llSay(0, "Sounds ON");
@@ -347,7 +364,7 @@ state running
                 if (index != -1)
                 {
                     start_sequence(index);
-                    if ((~llListFindList(CURRENT_SEQUENCE_ACTIONS, ["WAIT"])) && (~llListFindList(CURRENT_SEQUENCE_ACTIONS, ["PLAY"])))
+                    if (~llListFindList(CURRENT_SEQUENCE_ACTIONS, ["WAIT"]) && ~llListFindList(CURRENT_SEQUENCE_ACTIONS, ["PLAY"]))
                     {
                         sequence_control();
                     }
@@ -360,6 +377,7 @@ state running
             }
         }
     }
+
     listen(integer listen_channel, string name, key id, string msg)
     {
         if (msg == "▮▮")
@@ -401,21 +419,26 @@ state running
         }
         sequence_control();
     }
+
     timer()
     {
         llSetTimerEvent(0);
         SEQUENCE_POINTER++;
         run_sequence();
     }
+
     on_rez(integer start)
     {
         playsounds = TRUE;
     }
+
     changed(integer change)
     {
+        /*
         if (change & CHANGED_LINK)
         {
         }
+        */
         if (change & CHANGED_INVENTORY)
         {
             if (llGetInventoryKey(notecard_name) != notecard_key || get_number_of_scripts() != llGetListLength(SITTERS))

--- a/AVsitter2/Plugins/AVsequence/[AV]sequence.lsl
+++ b/AVsitter2/Plugins/AVsequence/[AV]sequence.lsl
@@ -208,8 +208,7 @@ stop_sequence(integer stopSound)
 sequence_control()
 {
     llListenRemove(menu_handle);
-    // FIXME: float rounds up to 2147483648.0
-    menu_channel = ((integer)llFrand(2147483646) + 1) * -1;
+    menu_channel = ((integer)llFrand(0x7FFFFF80) + 1) * -1; // 7FFFFF80 = max float < 2^31
     string pauseplay = "▶";
     if (sequence_running)
     {

--- a/AVsitter2/Plugins/AVsequence/[AV]sequence.lsl
+++ b/AVsitter2/Plugins/AVsequence/[AV]sequence.lsl
@@ -85,7 +85,7 @@ run_sequence()
             if (playsounds)
             {
                 string sound = llList2String(data_list, 0);
-                float volume = (float)llList2String(data_list, 1);
+                float volume = llList2Float(data_list, 1);
                 llPlaySound(sound, volume);
                 DEBUGSay(2, "Playing sound " + sound + " at volume " + (string)volume);
             }
@@ -357,8 +357,8 @@ state running
             {
                 stop_sequence(TRUE);
                 list data = llParseStringKeepNulls(id, ["|"], []);
-                CONTROLLER = (key)llList2String(data, 0);
-                CONTROLLED = (key)llList2String(data, -1);
+                CONTROLLER = llList2Key(data, 0);
+                CONTROLLED = llList2Key(data, -1);
                 integer index = llListFindList(SEQUENCE_DATA_NAMES, [msg]);
                 if (index != -1)
                 {

--- a/AVsitter2/Plugins/AVsequence/[AV]sequence.lsl
+++ b/AVsitter2/Plugins/AVsequence/[AV]sequence.lsl
@@ -170,7 +170,7 @@ string parse_text(string say)
     integer i;
     for (i = 0; i < llGetListLength(SITTERS); i++)
     {
-        string sitter_name = llList2String(llParseString2List(llKey2Name(llList2String(SITTERS, i)), [" "], []), 0);
+        string sitter_name = llList2String(llParseString2List(llKey2Name(llList2Key(SITTERS, i)), [" "], []), 0);
         if (sitter_name == "")
         {
             sitter_name = "nobody";

--- a/AVsitter2/RELEASE.md
+++ b/AVsitter2/RELEASE.md
@@ -32,8 +32,12 @@ To create a release version like the ones available for download, you need to ha
 
 ## Creating the release
 
-Once you have the required tools, edit the Makefile in the AVsitter2 folder to suit your needs, then using a terminal (also called command interpreter, shell, console... depending on the operating system) change to that folder using `cd <path-to-folder>` and type `make`. That should generate a file called `AVsitter2.zip` with the packaged version.
+Once you have the required tools, edit the Makefile in the AVsitter2 folder to suit your needs, then using a terminal (also called command interpreter, shell, console... depending on the operating system) change to that folder using `cd <path-to-folder>` and type `make`. That should generate a file called `AVsitter2.zip` with the packaged version for SL, and another file called `AVsitter2-oss.zip` with the packaged version for OpenSim.
 
-If you only want the optimized scripts without zipping them, use `make optimized`. The optimized files will have an `.lslo` extension, and they are ready to be copied and pasted each into a Second Life script.
+If you only want the Second Life optimized scripts without zipping them, use `make optimized`. The optimized files will have an `.lslo` extension, and they are ready to be copied and pasted each into a Second Life script.
 
-If you want to remove the optimized scripts and the zip file, use `make clean` (you can regenerate them at any time by typing `make`).
+If you only want the OpenSim scripts without zipping them, use `make opensim`. The OpenSim files will have an `.oss` extension.
+
+If you only want the SL zip, use `make AVsitter2.zip`; if you only want the OS zip, use `make AVsitter2-oss.zip`.
+
+If you want to remove the optimized scripts and the zip files, use `make clean` (you can regenerate them at any time by typing `make`).

--- a/AVsitter2/RELEASE.md
+++ b/AVsitter2/RELEASE.md
@@ -1,0 +1,39 @@
+# Creating a release version
+
+## Needed tools
+
+To create a release version like the ones available for download, you need to have the following tools:
+
+### For Linux
+
+- **zip**. It comes in most distributions, e.g. for Debian or Ubuntu use `sudo apt-get install zip`; if it isn't available in yours, try this link: <http://www.info-zip.org/Zip.html#Downloads>
+- **Python 2.7**. It comes in most distributions, e.g. for Debian or Ubuntu use `sudo apt-get install python`; if it isn't available in yours, try this link: <https://www.python.org/downloads/>. **Important:** Python 3.x won't work; only Python 2.x will. Usually Python 2 and Python 3 can be installed side-by-side.
+- **make**. It comes in most distributions, e.g. for Debian or Ubuntu use `sudo apt-get install make`; if it isn't available in yours, try this link: <https://www.gnu.org/software/make/#download>
+- **GNU cpp**. It comes in most distributions, e.g. for Debian or Ubuntu use `sudo apt-get install cpp`. If it isn't available in yours, or you have trouble installing it, you can instead use **mcpp**, which is much more lightweight and is included in most distributions. It is also available at this link: <http://mcpp.sourceforge.net/download.html>.
+- [**LSL-PyOptimizer**](https://github.com/Sei-Lisa/LSL-PyOptimizer). Currently the latest master branch is used to create the releases, which you can download by clicking on "Clone or Download" in the top right.
+
+### For Mac OS/X
+
+- **zip** (*)
+- **Python 2.7** (*) **Important:** Python 3.x won't work; only Python 2.x will.
+- **make** (*)
+- [**mcpp**](http://mcpp.sourceforge.net/download.html). Alternatively you can use GNU cpp if you have it installed.
+- [**LSL-PyOptimizer**](https://github.com/Sei-Lisa/LSL-PyOptimizer). Currently the latest master branch is used to create the releases, which you can download by clicking on "Clone or Download" in the top right.
+
+(*) If you're an OS/X user and you know how to obtain these tools or whether they come pre-installed with the base system, we'd appreciate if you can help us by telling us how to do so, or even better, submit a pull request with the necessary changes to this file.
+
+### For Windows
+
+- [**zip**](http://www.info-zip.org/Zip.html#Downloads)
+- [**Python 2.7**](https://www.python.org/downloads/) **Important:** Python 3.x won't work; only Python 2.x will.
+- [**make**](http://gnuwin32.sourceforge.net/packages/make.htm#download)
+- [**mcpp**](http://mcpp.sourceforge.net/download.html)
+- [**LSL-PyOptimizer**](https://github.com/Sei-Lisa/LSL-PyOptimizer). Currently the latest master branch is used to create the releases, which you can download by clicking on "Clone or Download" in the top right.
+
+## Creating the release
+
+Once you have the required tools, edit the Makefile in the AVsitter2 folder to suit your needs, then using a terminal (also called command interpreter, shell, console... depending on the operating system) change to that folder using `cd <path-to-folder>` and type `make`. That should generate a file called `AVsitter2.zip` with the packaged version.
+
+If you only want the optimized scripts without zipping them, use `make optimized`. The optimized files will have an `.lslo` extension, and they are ready to be copied and pasted each into a Second Life script.
+
+If you want to remove the optimized scripts and the zip file, use `make clean` (you can regenerate them at any time by typing `make`).

--- a/AVsitter2/Utilities/AVpos-generator.lsl
+++ b/AVsitter2/Utilities/AVpos-generator.lsl
@@ -3,17 +3,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this 
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) the AVsitter Contributors (http://avsitter.github.io)
+ * Copyright © the AVsitter Contributors (http://avsitter.github.io)
  * AVsitter™ is a trademark. For trademark use policy see:
  * https://avsitter.github.io/TRADEMARK.mediawiki
- * 
+ *
  * Please consider supporting continued development of AVsitter and
  * receive automatic updates and other benefits! All details and user 
  * instructions can be found at http://avsitter.github.io
  */
- 
+
 string notecard_basename = "AVpos";
 string name = "Anim";
+
 Readout_Say(string say)
 {
     llSleep(0.2);
@@ -22,6 +23,7 @@ Readout_Say(string say)
     llRegionSayTo(llGetOwner(), 0, "◆" + say);
     llSetObjectName(objectname);
 }
+
 default
 {
     state_entry()

--- a/AVsitter2/Utilities/AVpos-shifter.lsl
+++ b/AVsitter2/Utilities/AVpos-shifter.lsl
@@ -3,15 +3,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this 
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) the AVsitter Contributors (http://avsitter.github.io)
+ * Copyright © the AVsitter Contributors (http://avsitter.github.io)
  * AVsitter™ is a trademark. For trademark use policy see:
  * https://avsitter.github.io/TRADEMARK.mediawiki
- * 
+ *
  * Please consider supporting continued development of AVsitter and
  * receive automatic updates and other benefits! All details and user 
  * instructions can be found at http://avsitter.github.io
  */
- 
+
 float version = 1.2;
 string notecard_name = "AVpos";
 string url = "https://avsitter.com/settings.php"; // the settings dump service remains up for AVsitter customers. settings clear periodically.
@@ -24,14 +24,18 @@ vector pos_offset;
 string cache;
 string webkey;
 integer webcount;
-web(string say, integer force){
-    cache+=say;
-    if(llStringLength(llEscapeURL(cache))>1024 || force){
-        webcount++;
-        llHTTPRequest(url, [HTTP_METHOD,"POST",HTTP_MIMETYPE,"application/x-www-form-urlencoded",HTTP_VERIFY_CERT,FALSE], "w="+webkey+"&c="+(string)webcount+"&t="+llEscapeURL(cache));
-        cache="";
+
+web(string say, integer force)
+{
+    cache += say;
+    if (llStringLength(llEscapeURL(cache)) > 1024 || force)
+    {
+        ++webcount;
+        llHTTPRequest(url, [HTTP_METHOD, "POST", HTTP_MIMETYPE, "application/x-www-form-urlencoded", HTTP_VERIFY_CERT, FALSE], "w=" + webkey + "&c=" + (string)webcount + "&t=" + llEscapeURL(cache));
+        cache = "";
     }
 }
+
 integer IsVector(string s)
 {
     list split = llParseString2List(s, [" "], ["<", ">", ","]);
@@ -39,6 +43,7 @@ integer IsVector(string s)
         return FALSE;
     return !((string)((vector)s) == (string)((vector)((string)llListInsertList(split, ["-"], 5))));
 }
+
 string FormatFloat(float f, integer num_decimals)
 {
     float rounding = (float)(".5e-" + (string)num_decimals) - 5e-07;
@@ -60,10 +65,12 @@ string FormatFloat(float f, integer num_decimals)
     }
     return ret;
 }
+
 instructions()
 {
     llOwnerSay("\n\nINSTRUCTIONS:\n\nFOR MOVING ALL POSE & PROP POSITIONS BY AN OFFSET:\nManual Position: specify a position offset on channel 5, and positions will be converted by that offset. E.g. /5 <0,0,1.5>\nManual Rotation: specify a rotation offset on channel 6 (in degrees), and rotations will be converted by that offset, relative to the prim center. E.g. /6 <0,0,180>\n\nFOR RELOCATING SCRIPTS TO NEW PRIM:\n1. Unlink your object and re-link so that the prim you want to move the animations from is the root prim, then place this script inside the root prim.\n2. Touch the prim you want to locate the poses to. This prim should be empty or contain a script with llPassTouches(TRUE);\n3. The script will read out the notecard in chat, with pos/rot modified to the prim you touched.\n\nHave Fun! :)\n");
 }
+
 cut_above_text()
 {
     webkey = (string)llGenerateKey();
@@ -72,12 +79,14 @@ cut_above_text()
     Readout_Say("--✄--COPY BELOW INTO \"AVpos\" NOTECARD--✄--");
     Readout_Say("");
 }
+
 cut_below_text()
 {
     Readout_Say("");
     Readout_Say("--✄--COPY ABOVE INTO \"AVpos\" NOTECARD--✄--");
     Readout_Say("");
 }
+
 Readout_Say(string say)
 {
     llSleep(0.1);
@@ -85,8 +94,9 @@ Readout_Say(string say)
     llSetObjectName("");
     llRegionSayTo(llGetOwner(), 0, "◆" + say);
     llSetObjectName(objectname);
-    web(say+"\n",FALSE);
+    web(say + "\n", FALSE);
 }
+
 integer check_in_root()
 {
     if (llGetLinkNumber() > 1 || llGetInventoryType("AVpos") != INVENTORY_NOTECARD)
@@ -100,6 +110,7 @@ integer check_in_root()
     }
     return TRUE;
 }
+
 default
 {
     state_entry()
@@ -109,6 +120,7 @@ default
         llListen(5, "", llGetOwner(), "");
         llListen(6, "", llGetOwner(), "");
     }
+
     touch_start(integer touched)
     {
         check_in_root();
@@ -122,6 +134,7 @@ default
             notecard_query = llGetNotecardLine(notecard_name, notecard_line);
         }
     }
+
     listen(integer chan, string name, key id, string msg)
     {
         if (chan == 5)
@@ -155,6 +168,7 @@ default
             }
         }
     }
+
     dataserver(key query_id, string data)
     {
         if (query_id == notecard_query)

--- a/AVsitter2/Utilities/AVpos-shifter.lsl
+++ b/AVsitter2/Utilities/AVpos-shifter.lsl
@@ -46,7 +46,7 @@ integer IsVector(string s)
 
 string FormatFloat(float f, integer num_decimals)
 {
-    float rounding = (float)(".5e-" + (string)num_decimals) - 5e-07;
+    float rounding = (float)(".5e-" + (string)num_decimals) - .5e-6;
     if (f < 0.)
         f -= rounding;
     else

--- a/AVsitter2/Utilities/Anim-perm-checker.lsl
+++ b/AVsitter2/Utilities/Anim-perm-checker.lsl
@@ -3,19 +3,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this 
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) the AVsitter Contributors (http://avsitter.github.io)
+ * Copyright © the AVsitter Contributors (http://avsitter.github.io)
  * AVsitter™ is a trademark. For trademark use policy see:
  * https://avsitter.github.io/TRADEMARK.mediawiki
- * 
+ *
  * Please consider supporting continued development of AVsitter and
  * receive automatic updates and other benefits! All details and user 
  * instructions can be found at http://avsitter.github.io
  */
- 
+
 Owner_Say(string say)
 {
     llOwnerSay(llGetScriptName() + ": " + say);
 }
+
 default
 {
     state_entry()

--- a/AVsitter2/Utilities/MLP-converter.lsl
+++ b/AVsitter2/Utilities/MLP-converter.lsl
@@ -36,7 +36,7 @@ Out(integer level, string out)
 
 string FormatFloat(float f, integer num_decimals)
 {
-    float rounding = (float)(".5e-" + (string)num_decimals) - 5e-07;
+    float rounding = (float)(".5e-" + (string)num_decimals) - .5e-6;
     if (f < 0.)
         f -= rounding;
     else

--- a/AVsitter2/Utilities/MLP-converter.lsl
+++ b/AVsitter2/Utilities/MLP-converter.lsl
@@ -3,15 +3,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this 
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) the AVsitter Contributors (http://avsitter.github.io)
+ * Copyright © the AVsitter Contributors (http://avsitter.github.io)
  * AVsitter™ is a trademark. For trademark use policy see:
  * https://avsitter.github.io/TRADEMARK.mediawiki
- * 
+ *
  * Please consider supporting continued development of AVsitter and
  * receive automatic updates and other benefits! All details and user 
  * instructions can be found at http://avsitter.github.io
  */
- 
+
 string product = "AVsitter2 MLP converter";
 string version = "2.2";
 string notecard_basename = "AVpos";
@@ -25,6 +25,7 @@ integer animator_count;
 integer animator_total;
 list ommit = ["default", "stand"];
 integer verbose = 0;
+
 Out(integer level, string out)
 {
     if (verbose >= level)
@@ -32,6 +33,7 @@ Out(integer level, string out)
         llOwnerSay(llGetScriptName() + "[" + version + "] " + out);
     }
 }
+
 string FormatFloat(float f, integer num_decimals)
 {
     float rounding = (float)(".5e-" + (string)num_decimals) - 5e-07;
@@ -39,7 +41,7 @@ string FormatFloat(float f, integer num_decimals)
         f -= rounding;
     else
         f += rounding;
-    string ret = llGetSubString((string)f, 0, num_decimals - (!num_decimals) - 7);
+    string ret = llGetSubString((string)f, 0, num_decimals - !num_decimals - 7);
     if (llSubStringIndex(ret, ".") != -1)
     {
         while (llGetSubString(ret, -1, -1) == "0")
@@ -53,6 +55,7 @@ string FormatFloat(float f, integer num_decimals)
     }
     return ret;
 }
+
 finish()
 {
     if (llSubStringIndex(llGetObjectName(), "Utilities") == -1) // remove it except from Utilities box
@@ -61,6 +64,7 @@ finish()
         llRemoveInventory(llGetScriptName());
     }
 }
+
 get_notecards()
 {
     integer i;
@@ -77,6 +81,7 @@ get_notecards()
         }
     }
 }
+
 Readout_Say(string say)
 {
     string objectname = llGetObjectName();
@@ -84,6 +89,7 @@ Readout_Say(string say)
     llRegionSayTo(llGetOwner(), 0, "◆" + say);
     llSetObjectName(objectname);
 }
+
 default
 {
     state_entry()
@@ -105,6 +111,7 @@ default
             finish();
         }
     }
+
     dataserver(key query_id, string data)
     {
         if (query_id == notecard_query)

--- a/AVsitter2/Utilities/Missing-anim-finder.lsl
+++ b/AVsitter2/Utilities/Missing-anim-finder.lsl
@@ -3,24 +3,26 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this 
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) the AVsitter Contributors (http://avsitter.github.io)
+ * Copyright © the AVsitter Contributors (http://avsitter.github.io)
  * AVsitter™ is a trademark. For trademark use policy see:
  * https://avsitter.github.io/TRADEMARK.mediawiki
- * 
+ *
  * Please consider supporting continued development of AVsitter and
  * receive automatic updates and other benefits! All details and user 
  * instructions can be found at http://avsitter.github.io
  */
- 
+
 string notecard_basename = "AVpos";
 integer variable1;
 key notecard_query;
 list ALL_USED_ANIMATIONS;
 list UNUSED_ANIMS;
+
 Owner_Say(string say)
 {
     llOwnerSay(llGetScriptName() + ": " + say);
 }
+
 finish()
 {
     Owner_Say("Check complete, removing script.");
@@ -31,6 +33,7 @@ finish()
         llRemoveInventory(llGetScriptName());
     }
 }
+
 default
 {
     state_entry()
@@ -51,6 +54,7 @@ default
             }
         }
     }
+
     dataserver(key query_id, string data)
     {
         if (query_id == notecard_query)
@@ -100,6 +104,7 @@ default
             }
         }
     }
+
     listen(integer chan, string name, key id, string msg)
     {
         if (msg == "YES")
@@ -116,6 +121,7 @@ default
         }
         finish();
     }
+
     timer()
     {
         Owner_Say("timeout");

--- a/AVsitter2/Utilities/Updater/update-receiver.lsl
+++ b/AVsitter2/Utilities/Updater/update-receiver.lsl
@@ -3,23 +3,26 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this 
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) the AVsitter Contributors (http://avsitter.github.io)
+ * Copyright © the AVsitter Contributors (http://avsitter.github.io)
  * AVsitter™ is a trademark. For trademark use policy see:
  * https://avsitter.github.io/TRADEMARK.mediawiki
- * 
+ *
  * Please consider supporting continued development of AVsitter and
  * receive automatic updates and other benefits! All details and user 
  * instructions can be found at http://avsitter.github.io
  */
- 
+
 /*
  * Simple script used for updating a large number of furniture items at once
  * This script goes in each furniture prim that expects an update from the sender
  * will auto-delete if a non-admin avatar rezzes the furniture 
  */
- 
+
 integer pin = -29752;
+
+// Enter the list of allowed avatar UUIDs here.
 list admin_avatars = ["b30c9262-9abf-4cd1-9476-adcf5723c029", "f2e0ed5e-6592-4199-901d-a659c324ca94"];
+
 default
 {
     state_entry()
@@ -38,9 +41,10 @@ default
         llSetRemoteScriptAccessPin(pin);
         llListen(pin, "", "", "");
     }
+
     timer()
     {
-        if (llGetLinkNumber() == 0 || llGetLinkNumber() == 1 && llGetInventoryType("[AV]object") != INVENTORY_SCRIPT)
+        if ((llGetLinkNumber() == 0 || llGetLinkNumber() == 1) && llGetInventoryType("[AV]object") != INVENTORY_SCRIPT)
         {
             if (llGetAgentSize(llGetLinkKey(llGetNumberOfPrims())) == ZERO_VECTOR)
             {
@@ -49,6 +53,7 @@ default
         }
         llSetTimerEvent(10);
     }
+
     on_rez(integer start)
     {
         if (start)
@@ -60,6 +65,7 @@ default
             llRemoveInventory(llGetScriptName());
         }
     }
+
     listen(integer chan, string name, key id, string msg)
     {
         if (llGetOwnerKey(id) == llGetOwner())
@@ -83,6 +89,7 @@ default
             }
         }
     }
+
     changed(integer change)
     {
         if (change & CHANGED_OWNER)

--- a/AVsitter2/Utilities/Updater/update-sender.lsl
+++ b/AVsitter2/Utilities/Updater/update-sender.lsl
@@ -83,7 +83,7 @@ default
                 for (j = 0; j < llGetListLength(items); j = j + 2)
                 {
                     string item = llList2String(items, j);
-                    key item_key = (key)llList2String(items, j + 1);
+                    key item_key = llList2Key(items, j + 1);
                     if (item_key != llGetInventoryKey(item) || item_key == NULL_KEY)
                     {
                         if (llGetInventoryType(item) == INVENTORY_SCRIPT)

--- a/AVsitter2/Utilities/Updater/update-sender.lsl
+++ b/AVsitter2/Utilities/Updater/update-sender.lsl
@@ -3,10 +3,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this 
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) the AVsitter Contributors (http://avsitter.github.io)
+ * Copyright © the AVsitter Contributors (http://avsitter.github.io)
  * AVsitter™ is a trademark. For trademark use policy see:
  * https://avsitter.github.io/TRADEMARK.mediawiki
- * 
+ *
  * Please consider supporting continued development of AVsitter and
  * receive automatic updates and other benefits! All details and user 
  * instructions can be found at http://avsitter.github.io
@@ -18,19 +18,20 @@
  * (not running) scripts and inventory objects (e.g. prop objects) 
  * Touching the sender will shout in a radius and update all prims that respond.
  */
- 
+
 integer pin = -29752;
 string receiver_script = "update receiver (auto removing)";
 list objects_to_update;
 list objects_files;
 integer menu_handle;
 key av;
+
 particles_on(key target)
 {
      llParticleSystem([
      PSYS_PART_FLAGS, 0 | PSYS_PART_INTERP_COLOR_MASK | PSYS_PART_INTERP_SCALE_MASK | PSYS_PART_FOLLOW_VELOCITY_MASK | PSYS_PART_EMISSIVE_MASK | PSYS_PART_TARGET_POS_MASK,
      PSYS_SRC_PATTERN, 0 | PSYS_SRC_PATTERN_DROP,
-     PSYS_PART_START_ALPHA, 1.00000,
+     PSYS_PART_START_ALPHA, 1.0,
      PSYS_PART_END_ALPHA, 1,
      PSYS_PART_START_COLOR, <1, 0, 0>,
      PSYS_PART_END_COLOR, <0, 0, 1>,
@@ -40,17 +41,18 @@ particles_on(key target)
      PSYS_SRC_MAX_AGE, 0,
      PSYS_SRC_ACCEL, <0, 0, 0>,
      PSYS_SRC_BURST_PART_COUNT, 250,
-     PSYS_SRC_BURST_RADIUS, 0.00000,
+     PSYS_SRC_BURST_RADIUS, 0.0,
      PSYS_SRC_BURST_RATE, 0.05766,
      PSYS_SRC_BURST_SPEED_MIN, 0.07813,
      PSYS_SRC_BURST_SPEED_MAX, 0.15625,
      PSYS_SRC_INNERANGLE, 0.09375,
-     PSYS_SRC_OUTERANGLE, 0.00000,
+     PSYS_SRC_OUTERANGLE, 0.0,
      PSYS_SRC_OMEGA, <0, 0, 0>,
      PSYS_SRC_TEXTURE, (key)"",
      PSYS_SRC_TARGET_KEY, target
      ]);
 }
+
 default
 {
     state_entry()
@@ -58,10 +60,12 @@ default
         llParticleSystem([]);
         llListen(pin, "", "", "");
     }
+
     on_rez(integer x)
     {
         llResetScript();
     }
+
     timer()
     {
         llRegionSayTo(av, 0, "Found " + (string)llGetListLength(objects_to_update) + " objects...");
@@ -143,6 +147,7 @@ default
         llRegionSayTo(av, 0, "Updating Complete!");
         llResetScript();
     }
+
     touch_start(integer touched)
     {
         if (llDetectedKey(0) == llGetOwner() || llSameGroup(llDetectedKey(0)))
@@ -164,6 +169,7 @@ default
             llSay(pin, "OBJECT_SEARCH|" + llDumpList2String(items, "|"));
         }
     }
+
     listen(integer chan, string name, key id, string msg)
     {
         if (llGetOwnerKey(id) == llGetOwner())

--- a/AVsitter2/[AV]adjuster.lsl
+++ b/AVsitter2/[AV]adjuster.lsl
@@ -455,19 +455,19 @@ default
                         Readout_Say("--✄--COPY BELOW INTO \"AVpos\" NOTECARD--✄--");
                         Readout_Say("");
                         Readout_Say("\"" + llToUpper(llGetObjectName()) + "\" " + strReplace(llList2String(data, 0), "V:", "AVsitter "));
-                        if ((integer)llList2String(data, 1))
+                        if (llList2Integer(data, 1))
                         {
                             Readout_Say("MTYPE " + llList2String(data, 1));
                         }
-                        if ((integer)llList2String(data, 2) != 1)
+                        if (llList2Integer(data, 2) != 1)
                         {
                             Readout_Say("ETYPE " + llList2String(data, 2));
                         }
-                        if ((integer)llList2String(data, 3) > -1)
+                        if (llList2Integer(data, 3) > -1)
                         {
                             Readout_Say("SET " + llList2String(data, 3));
                         }
-                        if ((integer)llList2String(data, 4) != 2)
+                        if (llList2Integer(data, 4) != 2)
                         {
                             Readout_Say("SWAP " + llList2String(data, 4));
                         }
@@ -479,15 +479,15 @@ default
                         {
                             Readout_Say("ADJUST " + strReplace(llList2String(data, 7), "�", "|"));
                         }
-                        if ((integer)llList2String(data, 8))
+                        if (llList2Integer(data, 8))
                         {
                             Readout_Say("SELECT " + llList2String(data, 8));
                         }
-                        if ((integer)llList2String(data, 9) != 2)
+                        if (llList2Integer(data, 9) != 2)
                         {
                             Readout_Say("AMENU " + llList2String(data, 9));
                         }
-                        if ((integer)llList2String(data, 10))
+                        if (llList2Integer(data, 10))
                         {
                             Readout_Say("HELPER " + llList2String(data, 10));
                         }
@@ -564,8 +564,8 @@ default
                 }
                 else if (llList2String(data, 1) == "[NEW]")
                 {
-                    controller = (key)llList2String(data, 2);
-                    active_sitter = (integer)llList2String(data, 0);
+                    controller = llList2Key(data, 2);
+                    active_sitter = llList2Integer(data, 0);
                     adding = "";
                     new_menu();
                 }
@@ -594,7 +594,7 @@ default
                 else if (llList2String(data, 1) == "[HELPER]")
                 {
                     controller = id;
-                    OLD_HELPER_METHOD = (integer)llList2String(data, 3);
+                    OLD_HELPER_METHOD = llList2Integer(data, 3);
                     toggle_helper_mode();
                 }
                 else if (llList2String(data, 1) == "[ADJUST]")
@@ -866,7 +866,7 @@ default
         else if (llGetOwnerKey(id) == llGetOwner())
         {
             list data = llParseString2List(msg, ["|"], []);
-            integer num = (integer)llList2String(data, 1);
+            integer num = llList2Integer(data, 1);
             if (llList2String(data, 0) == "REG")
             {
                 HELPER_KEY_LIST = llListReplaceList(HELPER_KEY_LIST, [id], num, num);

--- a/AVsitter2/[AV]adjuster.lsl
+++ b/AVsitter2/[AV]adjuster.lsl
@@ -49,13 +49,13 @@ integer webcount;
 
 string FormatFloat(float f, integer num_decimals)
 {
-    float rounding = (float)(".5e-" + (string)num_decimals) - 5e-07;
+    float rounding = (float)(".5e-" + (string)num_decimals) - .5e-6;
     if (f < 0.)
         f -= rounding;
     else
         f += rounding;
     string ret = llGetSubString((string)f, 0, num_decimals - !num_decimals - 7);
-    if (~llSubStringIndex(ret, "."))
+    if (llSubStringIndex(ret, ".") != -1)
     {
         while (llGetSubString(ret, -1, -1) == "0")
         {
@@ -112,12 +112,12 @@ list order_buttons(list buttons)
 
 string strReplace(string str, string search, string replace)
 {
-    return llDumpList2String(llParseStringKeepNulls(str, [search], []), replace);
+    return llDumpList2String(llParseStringKeepNulls(str, [search], []), replace); // OSS::return osReplaceString(str, search, replace, -1, 0);
 }
 
 preview_anim(string anim, key id)
 {
-    if (id)
+    if (id) // OSS::if (osIsUUID(id) && id != NULL_KEY)
     {
         stop_all_anims(id);
         llMessageLinked(LINK_THIS, 90001, anim, id);
@@ -311,7 +311,7 @@ camera_menu()
 unsit_all()
 {
     integer i = llGetNumberOfPrims();
-    while (llGetAgentSize(llGetLinkKey(i)))
+    while (llGetAgentSize(llGetLinkKey(i)) != ZERO_VECTOR)
     {
         stop_all_anims(llGetLinkKey(i));
         llUnSit(llGetLinkKey(i));
@@ -355,7 +355,7 @@ default
 {
     state_entry()
     {
-        if (~llSubStringIndex(llGetScriptName(), " "))
+        if (llSubStringIndex(llGetScriptName(), " ") != -1)
         {
             remove_script("Use only one of this script!");
         }
@@ -386,7 +386,7 @@ default
             if (num == 90065)
             {
                 integer index = llListFindList(SITTERS, [id]);
-                if (~index)
+                if (index != -1)
                 {
                     SITTERS = llListReplaceList(SITTERS, [NULL_KEY], index, index);
                 }
@@ -471,11 +471,11 @@ default
                         {
                             Readout_Say("SWAP " + llList2String(data, 4));
                         }
-                        if (llList2String(data, 6))
+                        if (llList2String(data, 6) != "")
                         {
                             Readout_Say("TEXT " + strReplace(llList2String(data, 6), "\n", "\\n"));
                         }
-                        if (llList2String(data, 7))
+                        if (llList2String(data, 7) != "")
                         {
                             Readout_Say("ADJUST " + strReplace(llList2String(data, 7), "�", "|"));
                         }
@@ -496,7 +496,7 @@ default
                     if (llGetListLength(SITTERS) > 1 || llList2String(data, 5) != "")
                     {
                         string SITTER_TEXT;
-                        if (llList2String(data, 5))
+                        if (llList2String(data, 5) != "")
                         {
                             SITTER_TEXT = "|" + strReplace(llList2String(data, 5), "�", "|");
                         }
@@ -574,7 +574,7 @@ default
                     integer i;
                     for (i = 0; i < llGetListLength(SITTERS); i++)
                     {
-                        if (llList2String(SITTER_POSES, i))
+                        if (llList2String(SITTER_POSES, i) != "")
                         {
                             string type = "SYNC";
                             string temp_pose_name = llList2String(SITTER_POSES, i);
@@ -622,7 +622,7 @@ default
         {
             if (OLD_HELPER_METHOD)
             {
-                if (llGetAgentSize(llGetLinkKey(llGetNumberOfPrims())))
+                if (llGetAgentSize(llGetLinkKey(llGetNumberOfPrims())) != ZERO_VECTOR)
                 {
                     end_helper_mode();
                 }
@@ -779,7 +779,7 @@ default
             {
                 llRequestPermissions(id, PERMISSION_TRACK_CAMERA);
             }
-            else if (~llListFindList(["[DONE]", "1", "2", "3", "4", "5", "6", "7", "8", "9"], [msg]) && ~llListFindList(["[POSE]", "[SYNC]", "[SYNC]2", "[PROP]", "[FACE]"], [adding]))
+            else if (llListFindList(["[DONE]", "1", "2", "3", "4", "5", "6", "7", "8", "9"], [msg]) != -1 && llListFindList(["[POSE]", "[SYNC]", "[SYNC]2", "[PROP]", "[FACE]"], [adding]) != -1)
             {
                 string choice = llList2String(get_choices(), (integer)msg - 1);
                 if (adding == "[PROP]")

--- a/AVsitter2/[AV]adjuster.lsl
+++ b/AVsitter2/[AV]adjuster.lsl
@@ -422,7 +422,7 @@ default
                     }
                     if (llGetInventoryType(lookfor) == INVENTORY_SCRIPT)
                     {
-                        llMessageLinked(LINK_THIS, 90020, (string)script_channel, llList2String(scripts, index));
+                        llMessageLinked(LINK_THIS, 90020, (string)script_channel, llList2Key(scripts, index));
                         return;
                     }
                 }
@@ -874,7 +874,7 @@ default
             }
             else if (llList2String(data, 0) == "MENU")
             {
-                if (llList2String(data, 1) == controller)
+                if (llList2Key(data, 1) == controller)
                 {
                     llMessageLinked(LINK_SET, 90005, "", llDumpList2String([controller, llList2String(SITTERS, num)], "|"));
                 }

--- a/AVsitter2/[AV]adjuster.lsl
+++ b/AVsitter2/[AV]adjuster.lsl
@@ -3,15 +3,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this 
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) the AVsitter Contributors (http://avsitter.github.io)
+ * Copyright © the AVsitter Contributors (http://avsitter.github.io)
  * AVsitter™ is a trademark. For trademark use policy see:
  * https://avsitter.github.io/TRADEMARK.mediawiki
- * 
+ *
  * Please consider supporting continued development of AVsitter and
  * receive automatic updates and other benefits! All details and user 
  * instructions can be found at http://avsitter.github.io
  */
- 
+
 integer OLD_HELPER_METHOD;
 key key_request;
 string url = "https://avsitter.com/settings.php"; // the settings dump service remains up for AVsitter customers. settings clear periodically.
@@ -46,6 +46,7 @@ list chosen_animations;
 string cache;
 string webkey;
 integer webcount;
+
 string FormatFloat(float f, integer num_decimals)
 {
     float rounding = (float)(".5e-" + (string)num_decimals) - 5e-07;
@@ -53,7 +54,7 @@ string FormatFloat(float f, integer num_decimals)
         f -= rounding;
     else
         f += rounding;
-    string ret = llGetSubString((string)f, 0, num_decimals - (!num_decimals) - 7);
+    string ret = llGetSubString((string)f, 0, num_decimals - !num_decimals - 7);
     if (~llSubStringIndex(ret, "."))
     {
         while (llGetSubString(ret, -1, -1) == "0")
@@ -67,6 +68,7 @@ string FormatFloat(float f, integer num_decimals)
     }
     return ret;
 }
+
 web(integer force)
 {
     if (llStringLength(llEscapeURL(cache)) > 1024 || force)
@@ -81,6 +83,7 @@ web(integer force)
         cache = "";
     }
 }
+
 Readout_Say(string say)
 {
     string objectname = llGetObjectName();
@@ -91,6 +94,7 @@ Readout_Say(string say)
     say = "";
     web(FALSE);
 }
+
 stop_all_anims(key id)
 {
     list animations = llGetAnimationList(id);
@@ -100,14 +104,17 @@ stop_all_anims(key id)
         llMessageLinked(LINK_THIS, 90002, llList2String(animations, i), id);
     }
 }
+
 list order_buttons(list buttons)
 {
     return llList2List(buttons, -3, -1) + llList2List(buttons, -6, -4) + llList2List(buttons, -9, -7) + llList2List(buttons, -12, -10);
 }
+
 string strReplace(string str, string search, string replace)
 {
-    return llDumpList2String(llParseStringKeepNulls((str = "") + str, [search], []), replace);
+    return llDumpList2String(llParseStringKeepNulls(str, [search], []), replace);
 }
+
 preview_anim(string anim, key id)
 {
     if (id)
@@ -116,6 +123,7 @@ preview_anim(string anim, key id)
         llMessageLinked(LINK_THIS, 90001, anim, id);
     }
 }
+
 list get_choices()
 {
     integer my_number_per_page = number_per_page;
@@ -129,7 +137,28 @@ list get_choices()
     integer end = start + my_number_per_page;
     if (adding == "[FACE]")
     {
-        list facial_anim_list = ["none", "express_afraid_emote", "express_anger_emote", "express_laugh_emote", "express_bored_emote", "express_cry_emote", "express_embarrassed_emote", "express_sad_emote", "express_toothsmile", "express_smile", "express_surprise_emote", "express_worry_emote", "express_repulsed_emote", "express_shrug_emote", "express_wink_emote", "express_disdain", "express_frown", "express_kiss", "express_open_mouth", "express_tongue_out"];
+        list facial_anim_list =
+            [ "none"
+            , "express_afraid_emote"
+            , "express_anger_emote"
+            , "express_laugh_emote"
+            , "express_bored_emote"
+            , "express_cry_emote"
+            , "express_embarrassed_emote"
+            , "express_sad_emote"
+            , "express_toothsmile"
+            , "express_smile"
+            , "express_surprise_emote"
+            , "express_worry_emote"
+            , "express_repulsed_emote"
+            , "express_shrug_emote"
+            , "express_wink_emote"
+            , "express_disdain"
+            , "express_frown"
+            , "express_kiss"
+            , "express_open_mouth"
+            , "express_tongue_out"
+            ];
         i = llGetListLength(facial_anim_list);
         options = llList2List(facial_anim_list, start, end - 1);
     }
@@ -154,10 +183,12 @@ list get_choices()
     menu_pages = llCeil((float)i / my_number_per_page);
     return options;
 }
+
 ask_anim()
 {
     choice_menu(get_choices(), "Choose anim" + sitter_text(sitter_count) + ":");
 }
+
 choice_menu(list options, string menu_text)
 {
     last_text = menu_text;
@@ -196,6 +227,7 @@ choice_menu(list options, string menu_text)
     }
     llDialog(controller, menu_text, order_buttons(menu_items), comm_channel);
 }
+
 new_menu()
 {
     menu_page = 0;
@@ -208,15 +240,18 @@ new_menu()
     string menu_text = "\nWhat would you like to create?\n";
     llDialog(controller, menu_text, order_buttons(menu_items), comm_channel);
 }
+
 end_helper_mode()
 {
     llRegionSay(comm_channel, "DONEA");
     helper_mode = FALSE;
 }
+
 Out(string out)
 {
     llOwnerSay(llGetScriptName() + "[" + version + "] " + out);
 }
+
 integer get_number_of_scripts()
 {
     integer i;
@@ -224,6 +259,7 @@ integer get_number_of_scripts()
         ;
     return i;
 }
+
 string convert_to_world_positions(integer num)
 {
     list details = llGetObjectDetails(llGetLinkKey(llGetLinkNumber()), [OBJECT_POS, OBJECT_ROT]);
@@ -231,10 +267,12 @@ string convert_to_world_positions(integer num)
     vector target_pos = llList2Vector(POS_LIST, num) * llList2Rot(details, 1) + llList2Vector(details, 0);
     return (string)target_pos + "|" + (string)target_rot;
 }
+
 string sitter_text(integer sitter)
 {
     return " for SITTER " + (string)sitter;
 }
+
 remove_script(string reason)
 {
     string message = "\n" + llGetScriptName() + " ==Script Removed==\n\n" + reason;
@@ -242,6 +280,7 @@ remove_script(string reason)
     llInstantMessage(llGetOwner(), message);
     llRemoveInventory(llGetScriptName());
 }
+
 done_choosing_anims()
 {
     string adding_text = llList2String(llParseString2List(adding, ["[", "]"], []), 0);
@@ -254,6 +293,7 @@ done_choosing_anims()
     }
     llTextBox(controller, "\nType a menu name for " + adding_text + text, comm_channel);
 }
+
 camera_menu()
 {
     string text = "\nCamera:\n\n";
@@ -267,6 +307,7 @@ camera_menu()
     }
     llDialog(controller, text, ["[BACK]", "[SAVE]", "[CLEAR]"], comm_channel);
 }
+
 unsit_all()
 {
     integer i = llGetNumberOfPrims();
@@ -277,9 +318,10 @@ unsit_all()
         i--;
     }
 }
+
 toggle_helper_mode()
 {
-    helper_mode = (!helper_mode);
+    helper_mode = !helper_mode;
     if (helper_mode)
     {
         if (OLD_HELPER_METHOD)
@@ -308,6 +350,7 @@ toggle_helper_mode()
         end_helper_mode();
     }
 }
+
 default
 {
     state_entry()
@@ -332,6 +375,7 @@ default
             comm_channel -= 1000000000;
         }
     }
+
     link_message(integer sender, integer num, string msg, key id)
     {
         integer one = (integer)msg;
@@ -486,7 +530,7 @@ default
                     else
                     {
                         msg = strReplace(msg, "S:B:", "BUTTON ");
-                        if (!~llSubStringIndex(msg, "�"))
+                        if (llSubStringIndex(msg, "�") != -1)
                         {
                             msg = strReplace(msg, "|90200", "");
                         }
@@ -534,7 +578,7 @@ default
                         {
                             string type = "SYNC";
                             string temp_pose_name = llList2String(SITTER_POSES, i);
-                            if (!llSubStringIndex(llList2String(SITTER_POSES, i), "P:"))
+                            if (llSubStringIndex(llList2String(SITTER_POSES, i), "P:") == 0)
                             {
                                 type = "POSE";
                                 temp_pose_name = llGetSubString(temp_pose_name, 2, -1);
@@ -571,6 +615,7 @@ default
             }
         }
     }
+
     changed(integer change)
     {
         if (change & CHANGED_LINK)
@@ -594,6 +639,7 @@ default
             llResetScript();
         }
     }
+
     run_time_permissions(integer perm)
     {
         if (llGetPermissions() & PERMISSION_TRACK_CAMERA)
@@ -613,6 +659,7 @@ default
             camera_menu();
         }
     }
+
     listen(integer chan, string name, key id, string msg)
     {
         if (chan == chat_channel)
@@ -732,7 +779,7 @@ default
             {
                 llRequestPermissions(id, PERMISSION_TRACK_CAMERA);
             }
-            else if ((~llListFindList(["[DONE]", "1", "2", "3", "4", "5", "6", "7", "8", "9"], [msg])) && (~llListFindList(["[POSE]", "[SYNC]", "[SYNC]2", "[PROP]", "[FACE]"], [adding])))
+            else if (~llListFindList(["[DONE]", "1", "2", "3", "4", "5", "6", "7", "8", "9"], [msg]) && ~llListFindList(["[POSE]", "[SYNC]", "[SYNC]2", "[PROP]", "[FACE]"], [adding]))
             {
                 string choice = llList2String(get_choices(), (integer)msg - 1);
                 if (adding == "[PROP]")
@@ -859,6 +906,7 @@ default
             }
         }
     }
+
     on_rez(integer x)
     {
         llResetScript();

--- a/AVsitter2/[AV]helper.lsl
+++ b/AVsitter2/[AV]helper.lsl
@@ -3,15 +3,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this 
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) the AVsitter Contributors (http://avsitter.github.io)
+ * Copyright © the AVsitter Contributors (http://avsitter.github.io)
  * AVsitter™ is a trademark. For trademark use policy see:
  * https://avsitter.github.io/TRADEMARK.mediawiki
- * 
+ *
  * Please consider supporting continued development of AVsitter and
  * receive automatic updates and other benefits! All details and user 
  * instructions can be found at http://avsitter.github.io
  */
- 
+
 string registration_product = "AVsitter2";
 string product = "AVhelper";
 string version = "2.2";
@@ -28,6 +28,7 @@ vector default_size = <0.12,0.12,3.5>;
 key key_request;
 vector my_pos;
 rotation my_rot;
+
 stop_all_anims()
 {
     if (llAvatarOnSitTarget())
@@ -46,6 +47,7 @@ stop_all_anims()
         }
     }
 }
+
 set_text()
 {
     string text = "▽";
@@ -62,6 +64,7 @@ set_text()
     text = t + " " + (string)helper_index + "\n" + text;
     llSetLinkPrimitiveParamsFast(llGetLinkNumber(), [PRIM_TEXT, text, llList2Vector(colors, helper_index % llGetListLength(colors)), 1]);
 }
+
 setup()
 {
     alpha = llList2Float(llGetPrimitiveParams([PRIM_COLOR, 0]), 1);
@@ -88,6 +91,7 @@ setup()
     }
     llRegionSay(comm_channel, "REG|" + (string)sitter_number);
 }
+
 default
 {
     state_entry()
@@ -103,13 +107,14 @@ default
             llSetLinkPrimitiveParamsFast(LINK_THIS, [PRIM_TEXTURE, ALL_SIDES, "5748decc-f629-461c-9a36-a35a221fe21f", <1,1,0>, <0,0,0>, 0, PRIM_FULLBRIGHT, ALL_SIDES, TRUE]);
         }
         integer everyonePerms = llGetObjectPermMask(MASK_EVERYONE);
-        if ((!(everyonePerms & PERM_MOVE)) && llGetOwner() == llGetInventoryCreator(llGetScriptName()))
+        if (!(everyonePerms & PERM_MOVE) && llGetOwner() == llGetInventoryCreator(llGetScriptName()))
         {
             llOwnerSay("WARNING! AVhelper should be set to 'Anyone Can Move'");
         }
         llSitTarget(-<0,0,0.35>, ZERO_ROTATION);
         llSetStatus(STATUS_PHANTOM, TRUE);
     }
+
     on_rez(integer start)
     {
         llResetTime();
@@ -129,7 +134,7 @@ default
             sitter_number = helper_index;
             if (start < -1000000000)
             {
-                helper_index = (sitter_number = 0);
+                helper_index = sitter_number = 0;
             }
             comm_channel = llFloor(start / 1000) * 1000;
             llListen(5, "", "", "");
@@ -137,6 +142,7 @@ default
             setup();
         }
     }
+
     listen(integer chan, string name, key id, string msg)
     {
         if (chan == 5 && id == CURRENT_AV)
@@ -183,12 +189,12 @@ default
                 integer two = (integer)llList2String(data, 2);
                 if (sitter_number == one)
                 {
-                    sitter_number = (helper_index = two);
+                    sitter_number = helper_index = two;
                     setup();
                 }
                 else if (sitter_number == two)
                 {
-                    sitter_number = (helper_index = one);
+                    sitter_number = helper_index = one;
                     setup();
                 }
             }
@@ -216,6 +222,7 @@ default
             }
         }
     }
+
     timer()
     {
         if (my_pos != llGetPos() || my_rot != llGetRot())
@@ -229,6 +236,7 @@ default
             llDie();
         }
     }
+
     changed(integer change)
     {
         if (change & CHANGED_LINK)
@@ -255,6 +263,7 @@ default
             }
         }
     }
+
     touch_start(integer total_number)
     {
         if (llGetStartParameter() != 0)
@@ -262,6 +271,7 @@ default
             llRegionSay(comm_channel, "MENU|" + (string)llDetectedKey(0));
         }
     }
+
     run_time_permissions(integer perm)
     {
         if (perm & PERMISSION_TRIGGER_ANIMATION)

--- a/AVsitter2/[AV]helper.lsl
+++ b/AVsitter2/[AV]helper.lsl
@@ -185,8 +185,8 @@ default
             }
             else if (llList2String(data, 0) == "SWAP")
             {
-                integer one = (integer)llList2String(data, 1);
-                integer two = (integer)llList2String(data, 2);
+                integer one = llList2Integer(data, 1);
+                integer two = llList2Integer(data, 2);
                 if (sitter_number == one)
                 {
                     sitter_number = helper_index = two;
@@ -204,8 +204,8 @@ default
                 {
                     vector pos = (vector)llList2String(data, 2);
                     rotation rot = (rotation)llList2String(data, 3);
-                    OLD_HELPER_METHOD = (integer)llList2String(data, 4);
-                    CURRENT_AV = (key)llList2String(data, 5);
+                    OLD_HELPER_METHOD = llList2Integer(data, 4);
+                    CURRENT_AV = llList2Key(data, 5);
                     if (OLD_HELPER_METHOD)
                     {
                         llSetClickAction(CLICK_ACTION_SIT);

--- a/AVsitter2/[AV]helper.lsl
+++ b/AVsitter2/[AV]helper.lsl
@@ -31,11 +31,11 @@ rotation my_rot;
 
 stop_all_anims()
 {
-    if (llAvatarOnSitTarget())
+    if (llAvatarOnSitTarget()) // OSS::if (llAvatarOnSitTarget() != NULL_KEY)
     {
         if (llGetPermissions() & PERMISSION_TRIGGER_ANIMATION)
         {
-            if (llGetAgentSize(llGetPermissionsKey()))
+            if (llGetAgentSize(llGetPermissionsKey()) != ZERO_VECTOR)
             {
                 list anims = llGetAnimationList(llGetPermissionsKey());
                 integer n;
@@ -148,9 +148,9 @@ default
         if (chan == 5 && id == CURRENT_AV)
         {
             key av = (key)msg;
-            if (av)
+            if (av) // OSS::if (osIsUUID(av) && av != NULL_KEY)
             {
-                if (llGetAgentSize(av))
+                if (llGetAgentSize(av) != ZERO_VECTOR)
                 {
                     list avatar_location = llGetObjectDetails(av, [OBJECT_POS, OBJECT_ROT]);
                     if (llVecMag(llGetPos() - llList2Vector(avatar_location, 0)) < 10)
@@ -175,7 +175,7 @@ default
             {
                 if (OLD_HELPER_METHOD)
                 {
-                    if (llAvatarOnSitTarget())
+                    if (llAvatarOnSitTarget()) // OSS::if (llAvatarOnSitTarget() != NULL_KEY)
                     {
                         stop_all_anims();
                         llRegionSay(comm_channel, "GETUP");
@@ -244,7 +244,7 @@ default
             key av = llAvatarOnSitTarget();
             if (OLD_HELPER_METHOD)
             {
-                if (av)
+                if (av) // OSS::if (osIsUUID(av) && av != NULL_KEY)
                 {
                     llRequestPermissions(av, PERMISSION_TRIGGER_ANIMATION);
                     llRegionSay(comm_channel, "ANIMA|" + (string)av);
@@ -256,7 +256,7 @@ default
                     CURRENT_AV = "";
                 }
             }
-            else if (av)
+            else if (av) // OSS::if (osIsUUID(av) && av != NULL_KEY)
             {
                 llUnSit(av);
                 llDialog(av, product + " " + version + "\n\nDo not sit on the helper with AVsitter2 unless you have enabled the old helper mode. Move the helper while sitting on the furniture. Please see instructions at http://avsitter.com", ["OK"], -68154283);

--- a/AVsitter2/[AV]root-security.lsl
+++ b/AVsitter2/[AV]root-security.lsl
@@ -157,8 +157,8 @@ default
                 if (id == llGetOwner())
                 {
                     active_prim = sender;
-                    active_script_channel = (integer)llList2String(data, 0);
-                    active_sitter = (key)llList2String(data, 2);
+                    active_script_channel = llList2Integer(data, 0);
+                    active_sitter = llList2Key(data, 2);
                     main_menu();
                 }
                 else

--- a/AVsitter2/[AV]root-security.lsl
+++ b/AVsitter2/[AV]root-security.lsl
@@ -109,8 +109,7 @@ main_menu()
 dialog(string text, list menu_items)
 {
     llListenRemove(menu_handle);
-    // FIXME: 2147483646 rounds up to 2147483648.0
-    menu_handle = llListen(menu_channel = ((integer)llFrand(2147483646) + 1) * -1, "", llGetOwner(), "");
+    menu_handle = llListen(menu_channel = ((integer)llFrand(0x7FFFFF80) + 1) * -1, "", llGetOwner(), ""); // 7FFFFF80 = max float < 2^31
     llDialog(llGetOwner(), product + "\n\n" + text, order_buttons(menu_items), menu_channel);
     llSetTimerEvent(600);
 }

--- a/AVsitter2/[AV]root-security.lsl
+++ b/AVsitter2/[AV]root-security.lsl
@@ -3,15 +3,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this 
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) the AVsitter Contributors (http://avsitter.github.io)
+ * Copyright © the AVsitter Contributors (http://avsitter.github.io)
  * AVsitter™ is a trademark. For trademark use policy see:
  * https://avsitter.github.io/TRADEMARK.mediawiki
- * 
+ *
  * Please consider supporting continued development of AVsitter and
  * receive automatic updates and other benefits! All details and user 
  * instructions can be found at http://avsitter.github.io
  */
- 
+
 string product = "AVsitter™ Security 2.2";
 string script_basename = "[AV]sitA";
 string menucontrol_script = "[AV]root-control";
@@ -26,6 +26,7 @@ list MENU_TYPES = ["ALL", "OWNER", "GROUP"];
 integer SIT_INDEX;
 integer MENU_INDEX;
 string lastmenu;
+
 integer pass_security(key id, string context)
 {
     integer ALLOWED = FALSE;
@@ -47,6 +48,7 @@ integer pass_security(key id, string context)
     }
     return ALLOWED;
 }
+
 check_sitters()
 {
     integer i = llGetNumberOfPrims();
@@ -61,14 +63,17 @@ check_sitters()
         i--;
     }
 }
+
 back_to_adjust(integer SCRIPT_CHANNEL, key sitter)
 {
     llMessageLinked(LINK_SET, 90101, (string)SCRIPT_CHANNEL + "|[ADJUST]", sitter);
 }
+
 list order_buttons(list menu_items)
 {
     return llList2List(menu_items, -3, -1) + llList2List(menu_items, -6, -4) + llList2List(menu_items, -9, -7) + llList2List(menu_items, -12, -10);
 }
+
 register_touch(key id, integer animation_menu_function, integer active_prim, integer giveFailedMessage)
 {
     if (pass_security(id, "MENU"))
@@ -94,18 +99,22 @@ register_touch(key id, integer animation_menu_function, integer active_prim, int
         llDialog(id, product + "\n\nSorry, Menu access is set to: " + llList2String(MENU_TYPES, MENU_INDEX), [], -164289491);
     }
 }
+
 main_menu()
 {
     dialog("Sit access: " + llList2String(SIT_TYPES, SIT_INDEX) + "\nMenu access: " + llList2String(MENU_TYPES, MENU_INDEX) + "\n\nChange security settings:", ["[BACK]", "Sit", "Menu"]);
     lastmenu = "";
 }
+
 dialog(string text, list menu_items)
 {
     llListenRemove(menu_handle);
+    // FIXME: 2147483646 rounds up to 2147483648.0
     menu_handle = llListen(menu_channel = ((integer)llFrand(2147483646) + 1) * -1, "", llGetOwner(), "");
     llDialog(llGetOwner(), product + "\n\n" + text, order_buttons(menu_items), menu_channel);
     llSetTimerEvent(600);
 }
+
 integer check_for_RLV()
 {
     if (llGetInventoryType(RLV_script) == INVENTORY_SCRIPT)
@@ -114,17 +123,20 @@ integer check_for_RLV()
     }
     return FALSE;
 }
+
 default
 {
     state_entry()
     {
         llMessageLinked(LINK_SET, 90202, (string)check_for_RLV(), "");
     }
+
     timer()
     {
         llSetTimerEvent(0);
         llListenRemove(menu_handle);
     }
+
     link_message(integer sender, integer num, string msg, key id)
     {
         if (num == 90201)
@@ -162,6 +174,7 @@ default
             llListenRemove(menu_handle);
         }
     }
+
     listen(integer listen_channel, string name, key id, string msg)
     {
         if (msg == "Sit")
@@ -198,6 +211,7 @@ default
         }
         llListenRemove(menu_handle);
     }
+
     changed(integer change)
     {
         if (change & CHANGED_LINK)
@@ -205,6 +219,7 @@ default
             check_sitters();
         }
     }
+
     touch_end(integer touched)
     {
         if (check_for_RLV() || llGetAgentSize(llGetLinkKey(llGetNumberOfPrims())) != ZERO_VECTOR)

--- a/AVsitter2/[AV]root-security.lsl
+++ b/AVsitter2/[AV]root-security.lsl
@@ -164,7 +164,7 @@ default
                 else
                 {
                     llRegionSayTo(id, 0, "Sorry, only the owner can change security settings.");
-                    llMessageLinked(sender, 90101, llDumpList2String([llList2String(data, 0), "[ADJUST]", id], "|"), llList2String(data, 2));
+                    llMessageLinked(sender, 90101, llDumpList2String([llList2String(data, 0), "[ADJUST]", id], "|"), llList2Key(data, 2));
                 }
             }
         }

--- a/AVsitter2/[AV]root.lsl
+++ b/AVsitter2/[AV]root.lsl
@@ -3,17 +3,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this 
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) the AVsitter Contributors (http://avsitter.github.io)
+ * Copyright © the AVsitter Contributors (http://avsitter.github.io)
  * AVsitter™ is a trademark. For trademark use policy see:
  * https://avsitter.github.io/TRADEMARK.mediawiki
- * 
+ *
  * Please consider supporting continued development of AVsitter and
  * receive automatic updates and other benefits! All details and user 
  * instructions can be found at http://avsitter.github.io
  */
- 
+
 string script_basename = "[AV]sitA";
 string menu_script = "[AV]menu";
+
 default
 {
     touch_end(integer touched)

--- a/AVsitter2/[AV]select.lsl
+++ b/AVsitter2/[AV]select.lsl
@@ -3,15 +3,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this 
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) the AVsitter Contributors (http://avsitter.github.io)
+ * Copyright © the AVsitter Contributors (http://avsitter.github.io)
  * AVsitter™ is a trademark. For trademark use policy see:
  * https://avsitter.github.io/TRADEMARK.mediawiki
- * 
+ *
  * Please consider supporting continued development of AVsitter and
  * receive automatic updates and other benefits! All details and user 
  * instructions can be found at http://avsitter.github.io
  */
- 
+
 string product = "AVsitter™ seat select";
 string version = "2.2";
 integer select_type;
@@ -31,6 +31,7 @@ integer menu_handle;
 integer menu_type;
 integer variable1;
 integer verbose = 0;
+
 Out(integer level, string out)
 {
     if (verbose >= level)
@@ -38,14 +39,17 @@ Out(integer level, string out)
         llOwnerSay(llGetScriptName() + "[" + version + "] " + out);
     }
 }
+
 string strReplace(string str, string search, string replace)
 {
-    return llDumpList2String(llParseStringKeepNulls((str = "") + str, [search], []), replace);
+    return llDumpList2String(llParseStringKeepNulls(str, [search], []), replace);
 }
+
 list order_buttons(list buttons)
 {
     return llList2List(buttons, -3, -1) + llList2List(buttons, -6, -4) + llList2List(buttons, -9, -7) + llList2List(buttons, -12, -10);
 }
+
 menu(key av)
 {
     integer sitter_index = llListFindList(SITTERS, [av]);
@@ -56,7 +60,7 @@ menu(key av)
         for (i = 0; i < llGetListLength(BUTTONS); i++)
         {
             string avname = llKey2Name(llList2Key(SITTERS, i));
-            if ((!select_type) && llList2Integer(SYNCS, i) == FALSE || select_type == 2 && avname != "" && av != llList2Key(SITTERS, i))
+            if ((!select_type && llList2Integer(SYNCS, i) == FALSE || select_type == 2) && avname != "" && av != llList2Key(SITTERS, i))
             {
                 menu_buttons += "⊘" + llGetSubString(strReplace(avname, " Resident", " "), 0, 11);
             }
@@ -87,6 +91,7 @@ default
 {
     state_entry()
     {
+        // FIXME: 2147483646 rounds up to 2147483648.0
         menu_channel = ((integer)llFrand(2147483646) + 1) * -1;
         menu_handle = llListen(menu_channel, "", "", "");
         llListenControl(menu_handle, FALSE);
@@ -111,7 +116,7 @@ default
             {
                 llMessageLinked(LINK_SET, 90101, llDumpList2String(["X", message, id], "|"), id);
             }
-            else if (llGetSubString(message, 0, 0) == "⊘" || ((!select_type) && llList2Integer(SYNCS, button_index) == FALSE && llList2Key(SITTERS, button_index) != NULL_KEY && llList2Key(SITTERS, button_index) != id))
+            else if (llGetSubString(message, 0, 0) == "⊘" || (!select_type && llList2Integer(SYNCS, button_index) == FALSE && llList2Key(SITTERS, button_index) != NULL_KEY && llList2Key(SITTERS, button_index) != id))
             {
                 menu(id);
             }

--- a/AVsitter2/[AV]select.lsl
+++ b/AVsitter2/[AV]select.lsl
@@ -115,7 +115,7 @@ default
             {
                 llMessageLinked(LINK_SET, 90101, llDumpList2String(["X", message, id], "|"), id);
             }
-            else if (llGetSubString(message, 0, 0) == "⊘" || (!select_type && llList2Integer(SYNCS, button_index) == FALSE && llList2Key(SITTERS, button_index) != NULL_KEY && llList2Key(SITTERS, button_index) != id))
+            else if (llGetSubString(message, 0, 0) == "⊘" || (!select_type && llList2Integer(SYNCS, button_index) == FALSE && llList2String(SITTERS, button_index) != NULL_KEY && llList2Key(SITTERS, button_index) != id))
             {
                 menu(id);
             }

--- a/AVsitter2/[AV]select.lsl
+++ b/AVsitter2/[AV]select.lsl
@@ -91,8 +91,7 @@ default
 {
     state_entry()
     {
-        // FIXME: 2147483646 rounds up to 2147483648.0
-        menu_channel = ((integer)llFrand(2147483646) + 1) * -1;
+        menu_channel = ((integer)llFrand(0x7FFFFF80) + 1) * -1; // 7FFFFF80 = max float < 2^31
         menu_handle = llListen(menu_channel, "", "", "");
         llListenControl(menu_handle, FALSE);
         integer i;

--- a/AVsitter2/[AV]sitA.lsl
+++ b/AVsitter2/[AV]sitA.lsl
@@ -107,8 +107,7 @@ integer get_number_of_scripts()
 dialog(string text, list menu_items)
 {
     llListenRemove(menu_handle);
-    // FIXME: 2147483646 rounds up to 2147483648.0
-    menu_handle = llListen(menu_channel = ((integer)llFrand(2147483646) + 1) * -1, "", CONTROLLER, "");
+    menu_handle = llListen(menu_channel = ((integer)llFrand(0x7FFFFF80) + 1) * -1, "", CONTROLLER, ""); // 7FFFFF80 = max float < 2^31
     llDialog(CONTROLLER, product + " " + version + "\n\n" + text, order_buttons(menu_items), menu_channel);
 }
 

--- a/AVsitter2/[AV]sitA.lsl
+++ b/AVsitter2/[AV]sitA.lsl
@@ -3,15 +3,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this 
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) the AVsitter Contributors (http://avsitter.github.io)
+ * Copyright © the AVsitter Contributors (http://avsitter.github.io)
  * AVsitter™ is a trademark. For trademark use policy see:
  * https://avsitter.github.io/TRADEMARK.mediawiki
- * 
+ *
  * Please consider supporting continued development of AVsitter and
  * receive automatic updates and other benefits! All details and user 
  * instructions can be found at http://avsitter.github.io
  */
- 
+
 string product = "AVsitter™";
 string version = "2.2";
 string notecard_name = "AVpos";
@@ -82,6 +82,7 @@ string BRAND;
 string onSit;
 integer speed_index;
 integer verbose = 0;
+
 Out(integer level, string out)
 {
     if (verbose >= level)
@@ -89,10 +90,12 @@ Out(integer level, string out)
         llOwnerSay(llGetScriptName() + "[" + version + "] " + out);
     }
 }
+
 list order_buttons(list buttons)
 {
     return llList2List(buttons, -3, -1) + llList2List(buttons, -6, -4) + llList2List(buttons, -9, -7) + llList2List(buttons, -12, -10);
 }
+
 integer get_number_of_scripts()
 {
     integer i;
@@ -100,12 +103,15 @@ integer get_number_of_scripts()
         ;
     return i;
 }
+
 dialog(string text, list menu_items)
 {
     llListenRemove(menu_handle);
+    // FIXME: 2147483646 rounds up to 2147483648.0
     menu_handle = llListen(menu_channel = ((integer)llFrand(2147483646) + 1) * -1, "", CONTROLLER, "");
     llDialog(CONTROLLER, product + " " + version + "\n\n" + text, order_buttons(menu_items), menu_channel);
 }
+
 options_menu()
 {
     list menu_items;
@@ -139,6 +145,7 @@ options_menu()
     menu_items += "[POSE]";
     dialog("Adjust:", ["[BACK]"] + menu_items);
 }
+
 adjust_pose_menu()
 {
     string posrot_button = "Position";
@@ -150,10 +157,12 @@ adjust_pose_menu()
     }
     dialog("Personal adjustment:", ["[BACK]", posrot_button, value_button, "[DEFAULT]", "[SAVE]", "[SAVE ALL]", "X+", "Y+", "Z+", "X-", "Y-", "Z-"]);
 }
+
 integer IsInteger(string data)
 {
     return llParseString2List((string)llParseString2List(data, ["8", "9"], []), ["0", "1", "2", "3", "4", "5", "6", "7"], []) == [] && data != "";
 }
+
 wipe_sit_targets()
 {
     integer i;
@@ -166,10 +175,12 @@ wipe_sit_targets()
         }
     }
 }
+
 primcount_error()
 {
     llDialog(llGetOwner(), "\nThere aren't enough prims for required SitTargets.\nYou must have one prim for each avatar to sit!", [], 23658);
 }
+
 sittargets()
 {
     wrong_primcount = FALSE;
@@ -235,14 +246,16 @@ sittargets()
     prep();
     set_sittarget();
 }
+
 prep()
 {
-    has_security = (has_texture = FALSE);
+    has_security = has_texture = FALSE;
     if (!SCRIPT_CHANNEL)
     {
         llMessageLinked(LINK_SET, 90201, "", "");
     }
 }
+
 release_sitter(integer i)
 {
     SITTERS = llListReplaceList(SITTERS, [""], i, i);
@@ -263,6 +276,7 @@ release_sitter(integer i)
         }
     }
 }
+
 set_sittarget()
 {
     vector target_pos = DEFAULT_POSITION;
@@ -295,6 +309,7 @@ set_sittarget()
         llLinkSitTarget(target, target_pos - <0.,0.,0.4> + llRot2Up(target_rot) * 0.05, target_rot);
     }
 }
+
 update_current_anim_name()
 {
     list SEQUENCE = llParseStringKeepNulls(CURRENT_ANIMATION_SEQUENCE, ["�"], []);
@@ -306,6 +321,7 @@ update_current_anim_name()
     }
     llSetTimerEvent((float)llList2String(SEQUENCE, SEQUENCE_POINTER + 1));
 }
+
 apply_current_anim(integer broadcast)
 {
     SEQUENCE_POINTER = 0;
@@ -369,6 +385,7 @@ apply_current_anim(integer broadcast)
         }
     }
 }
+
 sit_using_prim_params()
 {
     integer sitter_prim = llGetNumberOfPrims();
@@ -389,22 +406,23 @@ sit_using_prim_params()
         localrot = llGetLocalRot();
         localpos = llGetLocalPos();
     }
-    if (HASKEYFRAME == 2 && (!llGetStatus(STATUS_PHYSICS)))
+    if (HASKEYFRAME == 2 && !llGetStatus(STATUS_PHYSICS))
     {
         llSleep(0.4);
     }
-    if (HASKEYFRAME && (!llGetStatus(STATUS_PHYSICS)))
+    if (HASKEYFRAME && !llGetStatus(STATUS_PHYSICS))
     {
         llSetKeyframedMotion([], [KFM_COMMAND, KFM_CMD_PAUSE]);
         llSleep(0.15);
     }
     llSetLinkPrimitiveParamsFast(sitter_prim, [PRIM_ROT_LOCAL, llEuler2Rot((CURRENT_ROTATION + <0,0,0.002>) * DEG_TO_RAD) * localrot, PRIM_POS_LOCAL, CURRENT_POSITION * localrot + localpos]);
-    if (HASKEYFRAME && (!llGetStatus(STATUS_PHYSICS)))
+    if (HASKEYFRAME && !llGetStatus(STATUS_PHYSICS))
     {
         llSleep(0.15);
         llSetKeyframedMotion([], [KFM_COMMAND, KFM_CMD_PLAY]);
     }
 }
+
 end_sitter()
 {
     llSetTimerEvent(0);
@@ -420,6 +438,7 @@ end_sitter()
         }
     }
 }
+
 default
 {
     state_entry()
@@ -454,11 +473,12 @@ default
             notecard_query = llGetNotecardLine(notecard_name, reused_variable);
         }
     }
+
     timer()
     {
         SEQUENCE_POINTER += 2;
         list SEQUENCE = llParseStringKeepNulls(CURRENT_ANIMATION_SEQUENCE, ["�"], []);
-        if (SEQUENCE_POINTER >= llGetListLength(SEQUENCE) || (~llListFindList(["M", "F"], llList2List(SEQUENCE, SEQUENCE_POINTER, SEQUENCE_POINTER))))
+        if (SEQUENCE_POINTER >= llGetListLength(SEQUENCE) || ~llListFindList(["M", "F"], llList2List(SEQUENCE, SEQUENCE_POINTER, SEQUENCE_POINTER)))
         {
             SEQUENCE_POINTER = 0;
         }
@@ -480,13 +500,15 @@ default
             }
         }
     }
+
     touch_end(integer touched)
     {
-        if ((!SCRIPT_CHANNEL) && (!has_security) && MTYPE < 3)
+        if (!SCRIPT_CHANNEL && !has_security && MTYPE < 3)
         {
             llMessageLinked(LINK_SET, 90005, "", llDetectedKey(0));
         }
     }
+
     listen(integer listen_channel, string name, key id, string msg)
     {
         integer index = llListFindList(ADJUST_MENU, [msg]);
@@ -554,7 +576,7 @@ default
             {
                 if (index < 2)
                 {
-                    pos_rot_adjust_toggle = (!pos_rot_adjust_toggle);
+                    pos_rot_adjust_toggle = !pos_rot_adjust_toggle;
                 }
                 else if (index < 8)
                 {
@@ -600,7 +622,7 @@ default
                 }
                 adjust_pose_menu();
             }
-            else if (msg == "[HELPER]" && id != llGetOwner() && (!~llSubStringIndex(llGetLinkName(!!llGetLinkNumber()), "HELPER")))
+            else if (msg == "[HELPER]" && id != llGetOwner() && llSubStringIndex(llGetLinkName(!!llGetLinkNumber()), "HELPER") == -1)
             {
                 dialog("Only the owner can rez the helpers. If the owner is nearby they can type '/5 helper' in chat.", ["[BACK]"]);
             }
@@ -610,6 +632,7 @@ default
             }
         }
     }
+
     link_message(integer sender, integer num, string msg, key id)
     {
         integer one = (integer)msg;
@@ -744,8 +767,8 @@ default
                 CURRENT_POSE_NAME = llList2String(data, 0);
                 OLD_ANIMATION_FILENAME = CURRENT_ANIMATION_FILENAME;
                 CURRENT_ANIMATION_SEQUENCE = llList2String(data, 1);
-                DEFAULT_POSITION = (CURRENT_POSITION = (vector)llList2String(data, 2));
-                DEFAULT_ROTATION = (CURRENT_ROTATION = (vector)llList2String(data, 3));
+                DEFAULT_POSITION = CURRENT_POSITION = (vector)llList2String(data, 2);
+                DEFAULT_ROTATION = CURRENT_ROTATION = (vector)llList2String(data, 3);
                 if (FIRST_POSENAME == "" || CURRENT_POSE_NAME == FIRST_POSENAME)
                 {
                     FIRST_POSENAME = CURRENT_POSE_NAME;
@@ -766,6 +789,7 @@ default
             }
         }
     }
+
     changed(integer change)
     {
         if (change & CHANGED_LINK)
@@ -922,9 +946,9 @@ default
                     }
                 }
             }
-            if (stood && (!llStringLength(llDumpList2String(SITTERS, ""))))
+            if (stood && (string)SITTERS == "")
             {
-                if (DFLT || (!~llSubStringIndex(CURRENT_POSE_NAME, "P:")))
+                if (DFLT || llSubStringIndex(CURRENT_POSE_NAME, "P:") == -1)
                 {
                     DEFAULT_POSITION = FIRST_POSITION;
                     DEFAULT_ROTATION = FIRST_ROTATION;
@@ -955,6 +979,7 @@ default
             }
         }
     }
+
     run_time_permissions(integer perm)
     {
         if (perm & PERMISSION_TRIGGER_ANIMATION)
@@ -970,7 +995,7 @@ default
                 animation_menu_function = -1;
             }
             reused_key = "";
-            SITTERS = llListReplaceList(SITTERS, [CONTROLLER = (MY_SITTER = llGetPermissionsKey())], SCRIPT_CHANNEL, SCRIPT_CHANNEL);
+            SITTERS = llListReplaceList(SITTERS, [CONTROLLER = MY_SITTER = llGetPermissionsKey()], SCRIPT_CHANNEL, SCRIPT_CHANNEL);
             string channel_or_swap = (string)SCRIPT_CHANNEL;
             integer lnk = 90000;
             if (SWAPPED)
@@ -1006,6 +1031,7 @@ default
             }
         }
     }
+
     dataserver(key query_id, string data)
     {
         if (query_id == notecard_query)
@@ -1143,8 +1169,8 @@ default
                         string rot = "<" + llList2String(parts, 2);
                         if (command == FIRST_POSENAME || "P:" + command == FIRST_POSENAME)
                         {
-                            FIRST_POSITION = (DEFAULT_POSITION = (CURRENT_POSITION = (vector)pos));
-                            FIRST_ROTATION = (DEFAULT_ROTATION = (CURRENT_ROTATION = (vector)rot));
+                            FIRST_POSITION = DEFAULT_POSITION = CURRENT_POSITION = (vector)pos;
+                            FIRST_ROTATION = DEFAULT_ROTATION = CURRENT_ROTATION = (vector)rot;
                         }
                         llMessageLinked(LINK_THIS, 90301, (string)SCRIPT_CHANNEL, command + "|" + pos + "|" + rot);
                     }
@@ -1170,8 +1196,8 @@ default
                             {
                                 if (FIRST_POSENAME == "")
                                 {
-                                    FIRST_POSENAME = (CURRENT_POSE_NAME = part0);
-                                    FIRST_ANIMATION_SEQUENCE = (CURRENT_ANIMATION_SEQUENCE = part1);
+                                    FIRST_POSENAME = CURRENT_POSE_NAME = part0;
+                                    FIRST_ANIMATION_SEQUENCE = CURRENT_ANIMATION_SEQUENCE = part1;
                                 }
                                 if (llList2String(parts, -1) == "M")
                                 {

--- a/AVsitter2/[AV]sitA.lsl
+++ b/AVsitter2/[AV]sitA.lsl
@@ -221,10 +221,10 @@ sittargets()
                 list data = llParseStringKeepNulls(desc, ["-"], []);
                 if (llGetListLength(data) == 2 && IsInteger(llList2String(data, 0)) && IsInteger(llList2String(data, 1)))
                 {
-                    if ((integer)llList2String(data, 0) == SET)
+                    if (llList2Integer(data, 0) == SET)
                     {
-                        SITTERS_SITTARGETS = llListReplaceList(SITTERS_SITTARGETS, [i], (integer)llList2String(data, 1), (integer)llList2String(data, 1));
-                        ASSIGNED_SITTARGETS = llListReplaceList(ASSIGNED_SITTARGETS, [TRUE], (integer)llList2String(data, 1), (integer)llList2String(data, 1));
+                        SITTERS_SITTARGETS = llListReplaceList(SITTERS_SITTARGETS, [i], llList2Integer(data, 1), llList2Integer(data, 1));
+                        ASSIGNED_SITTARGETS = llListReplaceList(ASSIGNED_SITTARGETS, [TRUE], llList2Integer(data, 1), llList2Integer(data, 1));
                         if (llListFindList(ASSIGNED_SITTARGETS, [FALSE]) == -1)
                         {
                             jump end;
@@ -318,7 +318,7 @@ update_current_anim_name()
     {
         CURRENT_ANIMATION_FILENAME += speed_text;
     }
-    llSetTimerEvent((float)llList2String(SEQUENCE, SEQUENCE_POINTER + 1));
+    llSetTimerEvent(llList2Float(SEQUENCE, SEQUENCE_POINTER + 1));
 }
 
 apply_current_anim(integer broadcast)
@@ -517,7 +517,7 @@ default
             {
                 id = llDumpList2String([id, MY_SITTER], "|");
             }
-            llMessageLinked(LINK_SET, (integer)llList2String(ADJUST_MENU, index + 1), msg, id);
+            llMessageLinked(LINK_SET, llList2Integer(ADJUST_MENU, index + 1), msg, id);
         }
         else
         {
@@ -721,7 +721,7 @@ default
             }
             else if (num == 90101)
             {
-                CONTROLLER = (key)llList2String(data, 2);
+                CONTROLLER = llList2Key(data, 2);
                 if (llList2String(data, 1) == "[ADJUST]")
                 {
                     options_menu();
@@ -775,8 +775,8 @@ default
                     FIRST_ROTATION = DEFAULT_ROTATION;
                     FIRST_ANIMATION_SEQUENCE = CURRENT_ANIMATION_SEQUENCE;
                 }
-                speed_index = (integer)llList2String(data, 5);
-                apply_current_anim((integer)llList2String(data, 4));
+                speed_index = llList2Integer(data, 5);
+                apply_current_anim(llList2Integer(data, 4));
                 set_sittarget();
             }
             else if (num == 90057)

--- a/AVsitter2/[AV]sitA.lsl
+++ b/AVsitter2/[AV]sitA.lsl
@@ -736,7 +736,7 @@ default
                     list X = SITTERS + SITTERS;
                     if (llSubStringIndex(CURRENT_POSE_NAME, "P:"))
                     {
-                        while (llList2Key(X, target_script) == "" && target_script + 1 < llGetListLength(X))
+                        while (llList2String(X, target_script) == "" && target_script + 1 < llGetListLength(X))
                         {
                             target_script++;
                         }
@@ -747,7 +747,7 @@ default
                     }
                     else
                     {
-                        while (llList2Key(X, target_script) != "" && target_script < llGetListLength(SITTERS) + SCRIPT_CHANNEL + 1)
+                        while (llList2String(X, target_script) != "" && target_script < llGetListLength(SITTERS) + SCRIPT_CHANNEL + 1)
                         {
                             target_script++;
                         }
@@ -866,7 +866,7 @@ default
                 }
                 for (i = 0; i < llGetListLength(SITTERS); i++)
                 {
-                    if (llList2Key(SITTERS, i) != "" && llListFindList(AVPRIMS, [llList2Key(SITTERS, i)]) == -1)
+                    if (llList2String(SITTERS, i) != "" && llListFindList(AVPRIMS, [llList2Key(SITTERS, i)]) == -1)
                     {
                         llSetTimerEvent(0);
                         stood = TRUE;

--- a/AVsitter2/[AV]sitA.lsl
+++ b/AVsitter2/[AV]sitA.lsl
@@ -107,7 +107,7 @@ integer get_number_of_scripts()
 dialog(string text, list menu_items)
 {
     llListenRemove(menu_handle);
-    menu_handle = llListen(menu_channel = ((integer)llFrand(0x7FFFFF80) + 1) * -1, "", CONTROLLER, ""); // 7FFFFF80 = max float < 2^31
+    menu_handle = llListen((menu_channel = ((integer)llFrand(0x7FFFFF80) + 1) * -1), "", CONTROLLER, ""); // 7FFFFF80 = max float < 2^31
     llDialog(CONTROLLER, product + " " + version + "\n\n" + text, order_buttons(menu_items), menu_channel);
 }
 
@@ -262,7 +262,7 @@ release_sitter(integer i)
     {
         if (llGetPermissions() & PERMISSION_TRIGGER_ANIMATION)
         {
-            if (MY_SITTER)
+            if (MY_SITTER) // OSS::if (osIsUUID(MY_SITTER) && MY_SITTER != NULL_KEY)
             {
                 llMessageLinked(LINK_SET, 90065, (string)SCRIPT_CHANNEL, MY_SITTER);
             }
@@ -340,7 +340,7 @@ apply_current_anim(integer broadcast)
     }
     if (llGetPermissions() & PERMISSION_TRIGGER_ANIMATION)
     {
-        if (llGetAgentSize(MY_SITTER))
+        if (llGetAgentSize(MY_SITTER) != ZERO_VECTOR)
         {
             if (broadcast)
             {
@@ -368,7 +368,7 @@ apply_current_anim(integer broadcast)
             {
                 sit_using_prim_params();
             }
-            if (CURRENT_ANIMATION_FILENAME)
+            if (CURRENT_ANIMATION_FILENAME != "")
             {
                 llStartAnimation(CURRENT_ANIMATION_FILENAME);
             }
@@ -388,7 +388,7 @@ apply_current_anim(integer broadcast)
 sit_using_prim_params()
 {
     integer sitter_prim = llGetNumberOfPrims();
-    while (llGetAgentSize(llGetLinkKey(sitter_prim)))
+    while (llGetAgentSize(llGetLinkKey(sitter_prim)) != ZERO_VECTOR)
     {
         if (llGetLinkKey(sitter_prim) == MY_SITTER)
         {
@@ -425,9 +425,9 @@ sit_using_prim_params()
 end_sitter()
 {
     llSetTimerEvent(0);
-    if (MY_SITTER)
+    if (MY_SITTER) // OSS::if (osIsUUID(MY_SITTER) && MY_SITTER != NULL_KEY)
     {
-        if (CURRENT_ANIMATION_FILENAME)
+        if (CURRENT_ANIMATION_FILENAME != "")
         {
             llStopAnimation(CURRENT_ANIMATION_FILENAME);
         }
@@ -477,7 +477,7 @@ default
     {
         SEQUENCE_POINTER += 2;
         list SEQUENCE = llParseStringKeepNulls(CURRENT_ANIMATION_SEQUENCE, ["�"], []);
-        if (SEQUENCE_POINTER >= llGetListLength(SEQUENCE) || ~llListFindList(["M", "F"], llList2List(SEQUENCE, SEQUENCE_POINTER, SEQUENCE_POINTER)))
+        if (SEQUENCE_POINTER >= llGetListLength(SEQUENCE) || llListFindList(["M", "F"], llList2List(SEQUENCE, SEQUENCE_POINTER, SEQUENCE_POINTER)) != -1)
         {
             SEQUENCE_POINTER = 0;
         }
@@ -485,9 +485,9 @@ default
         update_current_anim_name();
         if (llGetPermissions() & PERMISSION_TRIGGER_ANIMATION)
         {
-            if (llGetAgentSize(MY_SITTER))
+            if (llGetAgentSize(MY_SITTER) != ZERO_VECTOR)
             {
-                if (CURRENT_ANIMATION_FILENAME)
+                if (CURRENT_ANIMATION_FILENAME != "")
                 {
                     llStartAnimation(CURRENT_ANIMATION_FILENAME);
                 }
@@ -657,7 +657,7 @@ default
                 {
                     reused_key = llList2Key(SITTERS, two);
                 }
-                if (reused_key)
+                if (reused_key) // OSS::if (osIsUUID(reused_key) && reused_key != NULL_KEY)
                 {
                     SWAPPED = TRUE;
                     llRequestPermissions(reused_key, PERMISSION_TRIGGER_ANIMATION);
@@ -833,7 +833,7 @@ default
                         {
                             if (sitterGender)
                             {
-                                if (MALE_POSENAME)
+                                if (MALE_POSENAME != "")
                                 {
                                     if (CURRENT_POSE_NAME == FIRST_POSENAME)
                                     {
@@ -844,7 +844,7 @@ default
                             }
                             else
                             {
-                                if (FEMALE_POSENAME)
+                                if (FEMALE_POSENAME != "")
                                 {
                                     if (CURRENT_POSE_NAME == FIRST_POSENAME)
                                     {
@@ -875,7 +875,7 @@ default
                         {
                             if (llGetPermissions() & PERMISSION_TRIGGER_ANIMATION)
                             {
-                                if (MY_SITTER)
+                                if (MY_SITTER) // OSS::if (osIsUUID(MY_SITTER) && MY_SITTER != NULL_KEY)
                                 {
                                     llMessageLinked(LINK_SET, 90065, (string)SCRIPT_CHANNEL, MY_SITTER);
                                 }
@@ -900,7 +900,7 @@ default
                     {
                         actual_sitter = llAvatarOnSitTarget();
                     }
-                    if (existing_sitter)
+                    if (existing_sitter != "")
                     {
                         if (actual_sitter == NULL_KEY)
                         {
@@ -909,13 +909,13 @@ default
                             release_sitter(i);
                         }
                     }
-                    else if (actual_sitter)
+                    else if (actual_sitter) // OSS::else if (osIsUUID(actual_sitter) && actual_sitter != NULL_KEY)
                     {
                         if (i == SCRIPT_CHANNEL)
                         {
                             if (llList2Integer(llGetObjectDetails(actual_sitter, [OBJECT_BODY_SHAPE_TYPE]), 0))
                             {
-                                if (MALE_POSENAME)
+                                if (MALE_POSENAME != "")
                                 {
                                     if (CURRENT_POSE_NAME == FIRST_POSENAME)
                                     {
@@ -926,7 +926,7 @@ default
                             }
                             else
                             {
-                                if (FEMALE_POSENAME)
+                                if (FEMALE_POSENAME != "")
                                 {
                                     if (CURRENT_POSE_NAME == FIRST_POSENAME)
                                     {
@@ -994,7 +994,7 @@ default
                 animation_menu_function = -1;
             }
             reused_key = "";
-            SITTERS = llListReplaceList(SITTERS, [CONTROLLER = MY_SITTER = llGetPermissionsKey()], SCRIPT_CHANNEL, SCRIPT_CHANNEL);
+            SITTERS = llListReplaceList(SITTERS, [(CONTROLLER = MY_SITTER = llGetPermissionsKey())], SCRIPT_CHANNEL, SCRIPT_CHANNEL);
             string channel_or_swap = (string)SCRIPT_CHANNEL;
             integer lnk = 90000;
             if (SWAPPED)

--- a/AVsitter2/[AV]sitB.lsl
+++ b/AVsitter2/[AV]sitB.lsl
@@ -86,18 +86,18 @@ integer animation_menu(integer animation_menu_function)
     else
     {
         string menu = product + version;
-        if (BRAND)
+        if (BRAND != "")
             menu = BRAND;
         if (CONTROLLER != MY_SITTER || has_RLV)
         {
             menu += "\n\nMenu for " + llKey2Name(MY_SITTER);
         }
         menu += "\n\n";
-        if (CUSTOM_TEXT)
+        if (CUSTOM_TEXT != "")
         {
             menu += CUSTOM_TEXT + "\n";
         }
-        if (SITTER_INFO)
+        if (SITTER_INFO != "")
         {
             menu += "[" + llList2String(llParseStringKeepNulls(SITTER_INFO, ["�"], []), 0) + "]";
         }
@@ -112,7 +112,7 @@ integer animation_menu(integer animation_menu_function)
             anim_has_speeds = TRUE;
         }
         string CURRENT_POSE_NAME;
-        if (~FIRST_INDEX)
+        if (FIRST_INDEX != -1)
         {
             CURRENT_POSE_NAME = llList2String(MENU_LIST, ANIM_INDEX);
             menu += " [" + llList2String(llParseString2List(CURRENT_POSE_NAME, ["P:"], []), 0);
@@ -137,37 +137,37 @@ integer animation_menu(integer animation_menu_function)
         }
         list menu_items0;
         list menu_items2;
-        if (~current_menu || llGetInventoryType(select_script) == INVENTORY_SCRIPT)
+        if (current_menu != -1 || llGetInventoryType(select_script) == INVENTORY_SCRIPT)
         {
             menu_items0 += "[BACK]";
         }
         string submenu_info;
-        if (~current_menu)
+        if (current_menu != -1)
         {
             submenu_info = llList2String(DATA_LIST, current_menu);
         }
         if (helper_mode)
         {
             menu_items2 += "[NEW]";
-            if (CURRENT_POSE_NAME)
+            if (CURRENT_POSE_NAME != "")
             {
                 menu_items2 += "[DUMP]";
                 menu_items2 += "[SAVE]";
             }
         }
-        else if (~llSubStringIndex(submenu_info, "V"))
+        else if (llSubStringIndex(submenu_info, "V") != -1)
         {
             menu_items0 += "<< Softer";
             menu_items0 += "Harder >>";
         }
-        if (AMENU == 2 || (AMENU == 1 && current_menu == -1) || ~llSubStringIndex(submenu_info, "A"))
+        if (AMENU == 2 || (AMENU == 1 && current_menu == -1) || llSubStringIndex(submenu_info, "A") != -1)
         {
             if (!(OLD_HELPER_METHOD && helper_mode))
             {
                 menu_items2 += "[ADJUST]";
             }
         }
-        if (llSubStringIndex(onSit, "ASK") && ((current_menu == -1 && SWAP == 1) || SWAP == 2 || ~llSubStringIndex(submenu_info, "S")) && (number_of_sitters > 1 && llGetInventoryType(select_script) != INVENTORY_SCRIPT))
+        if (llSubStringIndex(onSit, "ASK") && ((current_menu == -1 && SWAP == 1) || SWAP == 2 || llSubStringIndex(submenu_info, "S") != -1) && (number_of_sitters > 1 && llGetInventoryType(select_script) != INVENTORY_SCRIPT))
         {
             menu_items2 += "[SWAP]";
         }
@@ -189,7 +189,7 @@ integer animation_menu(integer animation_menu_function)
             items_per_page -= 2;
         }
         list menu_items1;
-        integer page_start = i = current_menu + 1 + menu_page * items_per_page;
+        integer page_start = (i = current_menu + 1 + menu_page * items_per_page);
         do
         {
             if (i < llGetListLength(MENU_LIST))
@@ -257,7 +257,7 @@ default
             channel = (string)SCRIPT_CHANNEL;
             index = llListFindList(MENU_LIST, ["P:" + msg]);
         }
-        if (~index)
+        if (index != -1)
         {
             llMessageLinked(LINK_THIS, 90050, (string)channel + "|" + msg + "|" + (string)SET, MY_SITTER);
             llMessageLinked(LINK_THIS, 90000, msg, channel);
@@ -268,7 +268,7 @@ default
             return;
         }
         index = llListFindList(MENU_LIST, ["M:" + msg]);
-        if (~index)
+        if (index != -1)
         {
             llMessageLinked(LINK_SET, 90051, (string)channel + "|" + llGetSubString(msg, 0, -2) + "|" + (string)SET, MY_SITTER);
             menu_page = 0;
@@ -278,10 +278,10 @@ default
             return;
         }
         index = llListFindList(MENU_LIST, ["B:" + msg]);
-        if (~index)
+        if (index != -1)
         {
             list button_data = llParseStringKeepNulls(llList2String(DATA_LIST, index), ["�"], []);
-            if (llList2String(button_data, 1))
+            if (llList2String(button_data, 1) != "")
             {
                 msg = llList2String(button_data, 1);
             }
@@ -328,7 +328,7 @@ default
             }
             else
             {
-                if (~last_menu)
+                if (last_menu != -1)
                 {
                     current_menu = last_menu;
                     last_menu = -1;
@@ -336,10 +336,10 @@ default
                 else
                 {
                     current_menu = llListFindList(MENU_LIST, ["T:" + llGetSubString(llList2String(MENU_LIST, current_menu), 2, -1)]);
-                    if (~current_menu)
+                    if (current_menu != -1)
                     {
                         current_menu -= 1;
-                        while (~current_menu && llSubStringIndex(llList2String(MENU_LIST, current_menu), "M:") != 0)
+                        while (current_menu != -1 && llSubStringIndex(llList2String(MENU_LIST, current_menu), "M:") != 0)
                         {
                             current_menu--;
                         }
@@ -398,7 +398,7 @@ default
             {
                 doit = TRUE;
             }
-            else if (id)
+            else if (id) // OSS::else if (osIsUUID(id) && id != NULL_KEY)
             {
                 if (id == MY_SITTER)
                 {
@@ -409,7 +409,7 @@ default
             {
                 doit = TRUE;
             }
-            if (doit && (~index || msg == ""))
+            if (doit && (index != -1 || msg == ""))
             {
                 ANIM_INDEX = index;
                 integer broadcast = TRUE;
@@ -453,7 +453,7 @@ default
                 {
                     current_menu = -1;
                 }
-                else if (~index)
+                else if (index != -1)
                 {
                     last_menu = -1;
                     menu_page = 0;
@@ -556,7 +556,7 @@ default
                     {
                         FIRST_INDEX = place_to_add;
                     }
-                    if (~index)
+                    if (index != -1)
                     {
                         place_to_add = index;
                     }
@@ -568,7 +568,7 @@ default
             }
             else if (num == 90301)
             {
-                if (~index)
+                if (index != -1)
                 {
                     POS_ROT_LIST = llListReplaceList(POS_ROT_LIST, [(vector)llList2String(data, 1), (vector)llList2String(data, 2)], index * 2, index * 2 + 1);
                     if (llGetListLength(data) != 3)
@@ -608,7 +608,7 @@ default
                 i = -1;
                 while (++i < llGetListLength(MENU_LIST))
                 {
-                    if (llList2Vector(POS_ROT_LIST, i * 2))
+                    if (llList2Vector(POS_ROT_LIST, i * 2) != ZERO_VECTOR)
                     {
                         llSleep(0.2);
                         Readout_Say("{" + llList2String(MENU_LIST, i) + "}" + llList2String(POS_ROT_LIST, i * 2) + llList2String(POS_ROT_LIST, i * 2 + 1));

--- a/AVsitter2/[AV]sitB.lsl
+++ b/AVsitter2/[AV]sitB.lsl
@@ -3,15 +3,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this 
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) the AVsitter Contributors (http://avsitter.github.io)
+ * Copyright © the AVsitter Contributors (http://avsitter.github.io)
  * AVsitter™ is a trademark. For trademark use policy see:
  * https://avsitter.github.io/TRADEMARK.mediawiki
- * 
+ *
  * Please consider supporting continued development of AVsitter and
  * receive automatic updates and other benefits! All details and user 
  * instructions can be found at http://avsitter.github.io
  */
- 
+
 string product = "AVsitter™";
 string version = "2.2";
 string BRAND;
@@ -48,6 +48,7 @@ string RLVDesignations;
 string onSit;
 integer speed_index;
 integer verbose = 0;
+
 Out(integer level, string out)
 {
     if (verbose >= level)
@@ -55,25 +56,30 @@ Out(integer level, string out)
         llOwnerSay(llGetScriptName() + "[" + version + "]:" + out);
     }
 }
+
 send_anim_info(integer broadcast)
 {
     llMessageLinked(LINK_THIS, 90055, (string)SCRIPT_CHANNEL, llDumpList2String([llList2String(MENU_LIST, ANIM_INDEX), llList2String(DATA_LIST, ANIM_INDEX), llList2String(POS_ROT_LIST, ANIM_INDEX * 2), llList2String(POS_ROT_LIST, ANIM_INDEX * 2 + 1), broadcast, speed_index], "|"));
 }
+
 Readout_Say(string say)
 {
     llMessageLinked(LINK_THIS, 90022, say, (string)SCRIPT_CHANNEL);
 }
+
 list order_buttons(list buttons)
 {
     return llList2List(buttons, -3, -1) + llList2List(buttons, -6, -4) + llList2List(buttons, -9, -7) + llList2List(buttons, -12, -10);
 }
+
 memory()
 {
-    llOwnerSay(llGetScriptName() + "[" + version + "] " + (string)(MENU_LIST != []) + " Items Ready, Mem=" + (string)(65536 - llGetUsedMemory()));
+    llOwnerSay(llGetScriptName() + "[" + version + "] " + (string)llGetListLength(MENU_LIST) + " Items Ready, Mem=" + (string)(65536 - llGetUsedMemory()));
 }
+
 integer animation_menu(integer animation_menu_function)
 {
-    if (animation_menu_function == -1 || (MENU_LIST != []) < 2 && (!helper_mode) && llGetInventoryType(select_script) == INVENTORY_SCRIPT)
+    if ((animation_menu_function == -1 || llGetListLength(MENU_LIST) < 2) && !helper_mode && llGetInventoryType(select_script) == INVENTORY_SCRIPT)
     {
         llMessageLinked(LINK_SET, 90009, CONTROLLER, MY_SITTER);
     }
@@ -125,13 +131,13 @@ integer animation_menu(integer animation_menu_function)
         }
         integer total_items;
         integer i = current_menu + 1;
-        while (i++ < (MENU_LIST != []) && llSubStringIndex(llList2String(MENU_LIST, i), "M:"))
+        while (i++ < llGetListLength(MENU_LIST) && llSubStringIndex(llList2String(MENU_LIST, i), "M:"))
         {
             ++total_items;
         }
         list menu_items0;
         list menu_items2;
-        if ((~current_menu) || llGetInventoryType(select_script) == INVENTORY_SCRIPT)
+        if (~current_menu || llGetInventoryType(select_script) == INVENTORY_SCRIPT)
         {
             menu_items0 += "[BACK]";
         }
@@ -154,18 +160,18 @@ integer animation_menu(integer animation_menu_function)
             menu_items0 += "<< Softer";
             menu_items0 += "Harder >>";
         }
-        if (AMENU == 2 || (AMENU == 1 && (!~current_menu)) || (~llSubStringIndex(submenu_info, "A")))
+        if (AMENU == 2 || (AMENU == 1 && current_menu == -1) || ~llSubStringIndex(submenu_info, "A"))
         {
             if (!(OLD_HELPER_METHOD && helper_mode))
             {
                 menu_items2 += "[ADJUST]";
             }
         }
-        if (llSubStringIndex(onSit, "ASK") && ((!~current_menu) && SWAP == 1 || SWAP == 2 || (~llSubStringIndex(submenu_info, "S"))) && (number_of_sitters > 1 && (!(llGetInventoryType(select_script) == INVENTORY_SCRIPT))))
+        if (llSubStringIndex(onSit, "ASK") && ((current_menu == -1 && SWAP == 1) || SWAP == 2 || ~llSubStringIndex(submenu_info, "S")) && (number_of_sitters > 1 && llGetInventoryType(select_script) != INVENTORY_SCRIPT))
         {
             menu_items2 += "[SWAP]";
         }
-        if (!~current_menu)
+        if (current_menu == -1)
         {
             if (has_RLV && (llGetSubString(RLVDesignations, SCRIPT_CHANNEL, SCRIPT_CHANNEL) == "D" || CONTROLLER != MY_SITTER))
             {
@@ -176,7 +182,7 @@ integer animation_menu(integer animation_menu_function)
                 }
             }
         }
-        integer items_per_page = 12 - (menu_items2 != []) - (menu_items0 != []);
+        integer items_per_page = 12 - llGetListLength(menu_items2) - llGetListLength(menu_items0);
         if (items_per_page < total_items)
         {
             menu_items2 += ["[<<]", "[>>]"];
@@ -186,14 +192,14 @@ integer animation_menu(integer animation_menu_function)
         integer page_start = i = current_menu + 1 + menu_page * items_per_page;
         do
         {
-            if (i < (MENU_LIST != []))
+            if (i < llGetListLength(MENU_LIST))
             {
                 string m = llList2String(MENU_LIST, i);
                 if (!llSubStringIndex(m, "M:"))
                 {
                     jump end;
                 }
-                if (!~llListFindList(["T:", "P:", "B:"], [llGetSubString(m, 0, 1)]))
+                if (llListFindList(["T:", "P:", "B:"], [llGetSubString(m, 0, 1)]) == -1)
                 {
                     menu_items1 += m;
                 }
@@ -207,8 +213,8 @@ integer animation_menu(integer animation_menu_function)
         @end;
         if (animation_menu_function == 1)
         {
-            integer pages = total_items / (12 - (menu_items2 != []) - (menu_items0 != []));
-            if (!(total_items % (12 - (menu_items2 != []) - (menu_items0 != []))))
+            integer pages = total_items / (12 - llGetListLength(menu_items2) - llGetListLength(menu_items0));
+            if (!(total_items % (12 - llGetListLength(menu_items2) - llGetListLength(menu_items0))))
             {
                 pages--;
             }
@@ -216,7 +222,7 @@ integer animation_menu(integer animation_menu_function)
         }
         if (submenu_info == "V")
         {
-            while ((menu_items1 != []) < items_per_page)
+            while (llGetListLength(menu_items1) < items_per_page)
             {
                 menu_items1 += " ";
             }
@@ -227,6 +233,7 @@ integer animation_menu(integer animation_menu_function)
     }
     return 0;
 }
+
 default
 {
     state_entry()
@@ -240,11 +247,12 @@ default
             llResetOtherScript(main_script);
         }
     }
+
     listen(integer listen_channel, string name, key id, string msg)
     {
         string channel;
         integer index = llListFindList(MENU_LIST, [msg]);
-        if (!~index)
+        if (index == -1)
         {
             channel = (string)SCRIPT_CHANNEL;
             index = llListFindList(MENU_LIST, ["P:" + msg]);
@@ -293,7 +301,7 @@ default
         {
             if (msg == "[<<]")
             {
-                if (!~--menu_page)
+                if (--menu_page == -1)
                 {
                     menu_page = animation_menu(1);
                 }
@@ -310,7 +318,7 @@ default
         else if (msg == "[BACK]")
         {
             menu_page = 0;
-            if (!~current_menu)
+            if (current_menu == -1)
             {
                 if (llGetInventoryType(select_script) == INVENTORY_SCRIPT)
                 {
@@ -331,7 +339,7 @@ default
                     if (~current_menu)
                     {
                         current_menu -= 1;
-                        while ((~current_menu) && llSubStringIndex(llList2String(MENU_LIST, current_menu), "M:") != 0)
+                        while (~current_menu && llSubStringIndex(llList2String(MENU_LIST, current_menu), "M:") != 0)
                         {
                             current_menu--;
                         }
@@ -344,11 +352,12 @@ default
         {
             llMessageLinked(LINK_SET, 90100, llDumpList2String([SCRIPT_CHANNEL, msg, MY_SITTER], "|"), id);
         }
-        else if (!~index)
+        else if (index == -1)
         {
             llMessageLinked(LINK_SET, 90101, llDumpList2String([SCRIPT_CHANNEL, msg, CONTROLLER], "|"), MY_SITTER);
         }
     }
+
     changed(integer change)
     {
         if (change & CHANGED_LINK)
@@ -372,6 +381,7 @@ default
             }
         }
     }
+
     link_message(integer sender, integer num, string msg, key id)
     {
         integer one = (integer)msg;
@@ -379,7 +389,7 @@ default
         if (num == 90000 || num == 90010 || num == 90003)
         {
             integer index = llListFindList(MENU_LIST, [msg]);
-            if (!~index)
+            if (index == -1)
             {
                 index = llListFindList(MENU_LIST, ["P:" + msg]);
             }
@@ -399,7 +409,7 @@ default
             {
                 doit = TRUE;
             }
-            if (doit && ((~index) || msg == ""))
+            if (doit && (~index || msg == ""))
             {
                 ANIM_INDEX = index;
                 integer broadcast = TRUE;
@@ -455,7 +465,7 @@ default
         }
         else if (num == 90030 && (one == SCRIPT_CHANNEL || two == SCRIPT_CHANNEL))
         {
-            CONTROLLER = (MY_SITTER = "");
+            CONTROLLER = MY_SITTER = "";
         }
         else if (num == 90100 || num == 90101)
         {
@@ -463,8 +473,8 @@ default
             if (llList2String(data, 1) == "[HELPER]")
             {
                 menu_page = 0;
-                helper_mode = (!helper_mode);
-                if ((key)llList2String(data, 2) == MY_SITTER && (!OLD_HELPER_METHOD))
+                helper_mode = !helper_mode;
+                if ((key)llList2String(data, 2) == MY_SITTER && !OLD_HELPER_METHOD)
                 {
                     animation_menu(0);
                 }
@@ -501,25 +511,26 @@ default
         {
             list data = llParseStringKeepNulls(id, ["|"], []);
             integer index = llListFindList(MENU_LIST, [llList2String(data, 0)]);
-            if (!~index)
+            if (index == -1)
             {
                 index = llListFindList(MENU_LIST, ["P:" + llList2String(data, 0)]);
             }
             if (num == 90299)
             {
-                MENU_LIST = (DATA_LIST = (POS_ROT_LIST = []));
+                MENU_LIST = DATA_LIST = POS_ROT_LIST = [];
             }
             else if (num == 90070)
             {
-                CONTROLLER = (MY_SITTER = id);
+                CONTROLLER = MY_SITTER = id;
                 menu_page = 0;
                 current_menu = -1;
+                // FIXME: 2147483646 rounds up to 2147483648.0
                 menu_channel = ((integer)llFrand(2147483646) + 1) * -1;
                 llListenRemove(menu_handle);
             }
             else if (num == 90065 && sender == llGetLinkNumber())
             {
-                CONTROLLER = (MY_SITTER = "");
+                CONTROLLER = MY_SITTER = "";
                 llListenRemove(menu_handle);
             }
             else if (num == 90300)
@@ -528,11 +539,11 @@ default
                 if (llGetListLength(data) > 2)
                 {
                     place_to_add = current_menu;
-                    while (place_to_add < llGetListLength(MENU_LIST) && llSubStringIndex(llList2String(MENU_LIST, place_to_add + 1), "M:"))
+                    while (place_to_add < llGetListLength(MENU_LIST) && llSubStringIndex(llList2String(MENU_LIST, place_to_add + 1), "M:") != 0)
                     {
                         ++place_to_add;
                     }
-                    if (!llSubStringIndex(llList2String(MENU_LIST, place_to_add + 1), "M:"))
+                    if (llSubStringIndex(llList2String(MENU_LIST, place_to_add + 1), "M:") == 0)
                     {
                         ++place_to_add;
                     }
@@ -542,7 +553,7 @@ default
                 POS_ROT_LIST = llListInsertList(POS_ROT_LIST, [0, 0], place_to_add * 2);
                 if (llGetListLength(data) == 4)
                 {
-                    if (!~FIRST_INDEX)
+                    if (FIRST_INDEX == -1)
                     {
                         FIRST_INDEX = place_to_add;
                     }
@@ -575,7 +586,7 @@ default
                 MTYPE = (integer)llList2String(data, 3);
                 ETYPE = (integer)llList2String(data, 4);
                 SWAP = (integer)llList2String(data, 5);
-                FIRST_INDEX = (ANIM_INDEX = llListFindList(MENU_LIST, [llList2String(data, 6)]));
+                FIRST_INDEX = ANIM_INDEX = llListFindList(MENU_LIST, [llList2String(data, 6)]);
                 BRAND = llList2String(data, 7);
                 CUSTOM_TEXT = llList2String(data, 8);
                 ADJUST_MENU = llList2String(data, 9);
@@ -590,13 +601,13 @@ default
             {
                 Readout_Say("V:" + llDumpList2String([version, MTYPE, ETYPE, SET, SWAP, SITTER_INFO, CUSTOM_TEXT, ADJUST_MENU, SELECT, AMENU, OLD_HELPER_METHOD], "|"));
                 integer i = -1;
-                while (++i < (MENU_LIST != []))
+                while (++i < llGetListLength(MENU_LIST))
                 {
                     llSleep(0.5);
                     Readout_Say("S:" + llList2String(MENU_LIST, i) + "|" + llList2String(DATA_LIST, i));
                 }
                 i = -1;
-                while (++i < (MENU_LIST != []))
+                while (++i < llGetListLength(MENU_LIST))
                 {
                     if (llList2Vector(POS_ROT_LIST, i * 2))
                     {

--- a/AVsitter2/[AV]sitB.lsl
+++ b/AVsitter2/[AV]sitB.lsl
@@ -444,10 +444,10 @@ default
         else if (num == 90004 || num == 90005)
         {
             list data = llParseStringKeepNulls(id, ["|"], []);
-            if ((key)llList2String(data, -1) == MY_SITTER)
+            if (llList2Key(data, -1) == MY_SITTER)
             {
                 key lastController = CONTROLLER;
-                CONTROLLER = (key)llList2String(data, 0);
+                CONTROLLER = llList2Key(data, 0);
                 integer index = llListFindList(MENU_LIST, ["M:" + msg + "*"]);
                 if (num == 90004)
                 {
@@ -474,7 +474,7 @@ default
             {
                 menu_page = 0;
                 helper_mode = !helper_mode;
-                if ((key)llList2String(data, 2) == MY_SITTER && !OLD_HELPER_METHOD)
+                if (llList2Key(data, 2) == MY_SITTER && !OLD_HELPER_METHOD)
                 {
                     animation_menu(0);
                 }
@@ -579,19 +579,19 @@ default
             }
             else if (num == 90302)
             {
-                number_of_sitters = (integer)llList2String(data, 0);
+                number_of_sitters = llList2Integer(data, 0);
                 SITTER_INFO = llList2String(data, 1);
-                SET = (integer)llList2String(data, 2);
-                MTYPE = (integer)llList2String(data, 3);
-                ETYPE = (integer)llList2String(data, 4);
-                SWAP = (integer)llList2String(data, 5);
+                SET = llList2Integer(data, 2);
+                MTYPE = llList2Integer(data, 3);
+                ETYPE = llList2Integer(data, 4);
+                SWAP = llList2Integer(data, 5);
                 FIRST_INDEX = ANIM_INDEX = llListFindList(MENU_LIST, [llList2String(data, 6)]);
                 BRAND = llList2String(data, 7);
                 CUSTOM_TEXT = llList2String(data, 8);
                 ADJUST_MENU = llList2String(data, 9);
-                SELECT = (integer)llList2String(data, 10);
-                AMENU = (integer)llList2String(data, 11);
-                OLD_HELPER_METHOD = (integer)llList2String(data, 12);
+                SELECT = llList2Integer(data, 10);
+                AMENU = llList2Integer(data, 11);
+                OLD_HELPER_METHOD = llList2Integer(data, 12);
                 RLVDesignations = llList2String(data, 13);
                 onSit = llList2String(data, 14);
                 memory();

--- a/AVsitter2/[AV]sitB.lsl
+++ b/AVsitter2/[AV]sitB.lsl
@@ -524,8 +524,7 @@ default
                 CONTROLLER = MY_SITTER = id;
                 menu_page = 0;
                 current_menu = -1;
-                // FIXME: 2147483646 rounds up to 2147483648.0
-                menu_channel = ((integer)llFrand(2147483646) + 1) * -1;
+                menu_channel = ((integer)llFrand(0x7FFFFF80) + 1) * -1; // 7FFFFF80 = max float < 2^31
                 llListenRemove(menu_handle);
             }
             else if (num == 90065 && sender == llGetLinkNumber())

--- a/AVsitter2/[AV]sitB.lsl
+++ b/AVsitter2/[AV]sitB.lsl
@@ -288,7 +288,7 @@ default
             integer n = llList2Integer(button_data, 0);
             if (llGetListLength(button_data) > 2)
             {
-                id = llList2String(button_data, 2);
+                id = llList2Key(button_data, 2);
             }
             else if (CONTROLLER != MY_SITTER)
             {

--- a/AVsitter2/prepare-for-oss.py
+++ b/AVsitter2/prepare-for-oss.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+# coding: utf8
+
+import sys, re
+
+def prterr(s):
+    sys.stderr.write(s + "\n")
+
+def main(argc, argv):
+    if argc < 2:
+        prterr(u'Need exactly 1 argument (input filename)')
+        return 1
+
+    # Regex that replaces a line by its OSS version when one's specified.
+    os_re = re.compile(r'^( *)(.*?) // OSS::(.*)$', re.MULTILINE)
+
+    f = open(argv[1], "r");
+    s = f.read()
+    f.close()
+    # The U+FFFD character that AVsitter uses causes problems in OpenSim.
+    # Replace it with U+001F (Unit Separator) which works fine.
+    s = s.replace(b'\xEF\xBF\xBD', b'\x1F')
+
+    s = os_re.sub(r'\1\3', s)
+    sys.stdout.write(s)
+    return 0
+
+ret = main(len(sys.argv), sys.argv)
+if ret is not None and ret > 0:
+    sys.exit(ret)


### PR DESCRIPTION
This changeset:

- Adds `Makefile` and `RELEASE.md` to the `AVsitter2` subdirectory. The `RELEASE.md` file still lacks the OS/X version, which can be completed at a later time, and includes a call for help in that respect.
- Updates `.gitignore` to ignore `.lslo` files and `AVsitter2.zip` as well as Linux backup files.
- Makes a lot of cosmetic changes to the code, adding separators between functions, adding or removing parentheses, and changing the (c) in the notice to an actual copyright symbol.
- Fixes a few minor bugs found during the above preparations.

The middle commit probably needs no review. The only significant change is a minor optimization that removes a call to `llStringLength` and to `llDumpList2String` (line 925 of `[AV]sitA`), the first of which the optimizer does not currently handle.

I'm only unsure about the bump of `[AV]faces` to 2.2; please confirm whether it was an oversight or it was intentional to keep it at 2.1.

My intention was to also add comments on the meaning of the 90xxx constants where they are used, like I did for the `AVprop` subdirectory, but I ran out of time. That can be done after the release.

When this PR is dealt with, I'll add the tag and upload the release.