### PR TITLE
add listen handle

### DIFF
--- a/AVsitter2/Utilities/Updater/update-sender.lsl
+++ b/AVsitter2/Utilities/Updater/update-sender.lsl
@@ -25,6 +25,7 @@ list objects_to_update;
 list objects_files;
 integer menu_handle;
 key av;
+integer listenhandle;
 particles_on(key target)
 {
      llParticleSystem([
@@ -56,7 +57,7 @@ default
     state_entry()
     {
         llParticleSystem([]);
-        llListen(pin, "", "", "");
+        listenhandle=llListen(pin, "", "", "");
     }
     on_rez(integer x)
     {
@@ -64,6 +65,8 @@ default
     }
     timer()
     {
+    	llSetTimerEvent(0);
+    	llListenRemove(listenhandle);
         llRegionSayTo(av, 0, "Found " + (string)llGetListLength(objects_to_update) + " objects...");
         integer i;
         for (i = 0; i < llGetListLength(objects_to_update); i++)


### PR DESCRIPTION
The lack of a listen handle was preventing the script from re-initializing the listen in Kitely (OpenSim 0.8.2.1). Applying a listen handle and removing the listen seems to have fixed it. There is still a potential problem in OpenSim with the timer() event timing out when there are multiple items to update, which I have not looked into.