### PR TITLE
Fix bug with chains not detaching

### DIFF
--- a/AVsitter2/Plugins/AVcontrol/LockGuard/[AV]LockGuard.lsl
+++ b/AVsitter2/Plugins/AVcontrol/LockGuard/[AV]LockGuard.lsl
@@ -80,8 +80,7 @@ goChain(list new_links)
 //  unlink unused links
     for (; index < llGetListLength(links); index += 2)
     {
-        integer found = llListFindList(new_links, [llList2String(links, index)]);
-        if (~found)
+        if (llListFindList(new_links, [llList2String(links, index)]) == -1)
         {
             llWhisper(LOCKGUARD_CHANNEL, "lockguard " + (string)avatar + " " + llList2String(links, index) + " unlink");
         }


### PR DESCRIPTION
This bug was introduced in commit 5c4f5b3.

That prompts me to raise several points, which I will post in the docs issue tracker. I tried to review that commit, but the diff was too confusing and that bug slipped undetected and was shipped with 2.2.

Credit belongs to Natsagan for reporting the problem in the Unofficial AVsitter Support group.