### PR TITLE
Add AUTHORS.md

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,8 +1,8 @@
 # AVsitter contributors
 
-Code Violet <codeviolet@users.noreply.github.com> is the main author and has contributed the code base as open source under the Mozilla Public License 2.0. Other contributors are:
+Code Violet <`codeviolet@users.noreply.github.com`> is the main author and has contributed the code base as open source under the Mozilla Public License 2.0. Other contributors are:
 
-- Sei Lisa <Sei-Lisa@users.noreply.github.com>
-- Scottie Muircastle <Oddunity@users.noreply.github.com>
-- Auryn Beorn <AurynBeorn@users.noreply.github.com>
-- mifi3000 <mifi3000@users.noreply.github.com
+- Sei Lisa <`Sei-Lisa@users.noreply.github.com`>
+- Scottie Muircastle <`Oddunity@users.noreply.github.com`>
+- Auryn Beorn <`AurynBeorn@users.noreply.github.com`>
+- mifi3000 <`mifi3000@users.noreply.github.com`>

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,6 +1,6 @@
 # AVsitter contributors
 
-Code Violet <`codeviolet@users.noreply.github.com`> is the main author and has contributed the code base as open source under the Mozilla Public License 2.0. Other contributors are:
+Code Violet <`codeviolet@users.noreply.github.com`> is the initial author who contributed the code base as open source under the Mozilla Public License 2.0. Other contributors are:
 
 - Sei Lisa <`Sei-Lisa@users.noreply.github.com`>
 - Scottie Muircastle <`Oddunity@users.noreply.github.com`>

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,8 @@
+# AVsitter contributors
+
+Code Violet <codeviolet@users.noreply.github.com> is the main author and has contributed the code base as open source under the Mozilla Public License 2.0. Other contributors are:
+
+- Sei Lisa <Sei-Lisa@users.noreply.github.com>
+- Scottie Muircastle <Oddunity@users.noreply.github.com>
+- Auryn Beorn <AurynBeorn@users.noreply.github.com>
+- mifi3000 <mifi3000@users.noreply.github.com


### PR DESCRIPTION
This file is to specify who the "AVsitter contributors" mentioned in the licenses are.