### PR TITLE
use timer to avoid event timeout in OpenSim

### DIFF
--- a/AVsitter2/Utilities/Updater/update-sender.lsl
+++ b/AVsitter2/Utilities/Updater/update-sender.lsl
@@ -199,9 +199,9 @@ state do_update
         
         i++;
 
-		if(i==llGetListLength(objects_to_update)){        
-        	llRegionSayTo(av, 0, "Updates complete!");
-        	llResetScript();
-		}
+        if(i==llGetListLength(objects_to_update)){        
+            llRegionSayTo(av, 0, "Updates complete!");
+            llResetScript();
+        }
     }
 }


### PR DESCRIPTION
OpenSim has a configurable scripted event timeout (often set to 30 seconds) which caused the script to stop processing updates after the timeout period. Getting it to use a timer instead of a single event appears to avoid event timeout problem in OpenSim.