### PR TITLE
Change the strategy for the U+FFFD separator handling.

### DIFF
--- a/AVsitter2/Plugins/AVprop/[AV]menu.lsl
+++ b/AVsitter2/Plugins/AVprop/[AV]menu.lsl
@@ -39,6 +39,7 @@ integer listen_handle;
 integer number_per_page = 9;
 integer menu_pages;
 string last_text;
+string SEP = "�"; // OSS::string SEP;
 
 integer pass_security(key id)
 {
@@ -310,6 +311,7 @@ default
         {
             remove_script("Use only one copy of this script!");
         }
+        // OSS::SEP = llUnescapeURL("%7F");
         check_avsit();
         notecard_key = llGetInventoryKey(notecard_name);
         Out(0, "Loading...");
@@ -375,7 +377,7 @@ default
         mindex_test = llListFindList(MENU_LIST, ["B:" + msg]);
         if (mindex_test != -1)
         {
-            list button_data = llParseStringKeepNulls(llList2String(DATA_LIST, mindex_test), ["�"], []);
+            list button_data = llParseStringKeepNulls(llList2String(DATA_LIST, mindex_test), [SEP], []);
             if (llList2String(button_data, 1) != "")
             {
                 msg = llList2String(button_data, 1);
@@ -467,7 +469,7 @@ default
                     }
                     else if (llList2String(change_me, 0) == "B")
                     {
-                        list l = [llList2String(change_me, 1), strReplace(strReplace(llList2String(DATA_LIST, i), "90200", ""), "�", "|")];
+                        list l = [llList2String(change_me, 1), strReplace(strReplace(llList2String(DATA_LIST, i), "90200", ""), SEP, "|")];
                         if (llList2String(l, 1) == "")
                         {
                             l = llList2List(l, 0, 0);
@@ -594,7 +596,7 @@ default
                 string part1 = llList2String(parts, 1);
                 if (llGetListLength(parts) > 1)
                 {
-                    part1 = llStringTrim(llDumpList2String(llList2List(parts, 1, -1), "�"), STRING_TRIM);
+                    part1 = llStringTrim(llDumpList2String(llList2List(parts, 1, -1), SEP), STRING_TRIM);
                 }
                 if (command == "TEXT")
                 {

--- a/AVsitter2/[AV]adjuster.lsl
+++ b/AVsitter2/[AV]adjuster.lsl
@@ -46,6 +46,7 @@ list chosen_animations;
 string cache;
 string webkey;
 integer webcount;
+string SEP = "�"; // OSS::string SEP;
 
 string FormatFloat(float f, integer num_decimals)
 {
@@ -358,6 +359,7 @@ default
         {
             remove_script("Use only one of this script!");
         }
+        // OSS::SEP = llUnescapeURL("%7F");
         llListen(chat_channel, "", llGetOwner(), "");
         comm_channel = ((integer)llFrand(99999) + 1) * 1000 * -1;
         integer i;
@@ -476,7 +478,7 @@ default
                         }
                         if (llList2String(data, 7) != "")
                         {
-                            Readout_Say("ADJUST " + strReplace(llList2String(data, 7), "�", "|"));
+                            Readout_Say("ADJUST " + strReplace(llList2String(data, 7), SEP, "|"));
                         }
                         if ((integer)llList2String(data, 8))
                         {
@@ -497,7 +499,7 @@ default
                         string SITTER_TEXT;
                         if (llList2String(data, 5) != "")
                         {
-                            SITTER_TEXT = "|" + strReplace(llList2String(data, 5), "�", "|");
+                            SITTER_TEXT = "|" + strReplace(llList2String(data, 5), SEP, "|");
                         }
                         Readout_Say("SITTER " + (string)id + SITTER_TEXT);
                         Readout_Say("");
@@ -529,13 +531,13 @@ default
                     else
                     {
                         msg = strReplace(msg, "S:B:", "BUTTON ");
-                        if (llSubStringIndex(msg, "�") == -1)
+                        if (llSubStringIndex(msg, SEP) == -1)
                         {
                             msg = strReplace(msg, "|90200", "");
                         }
                     }
                     msg = strReplace(msg, "S:", "SYNC ");
-                    msg = strReplace(msg, "�", "|");
+                    msg = strReplace(msg, SEP, "|");
                 }
                 if (llGetSubString(msg, -1, -1) == "*")
                 {

--- a/AVsitter2/[AV]sitA.lsl
+++ b/AVsitter2/[AV]sitA.lsl
@@ -82,6 +82,7 @@ string BRAND;
 string onSit;
 integer speed_index;
 integer verbose = 0;
+string SEP = "�"; // OSS::string SEP;
 
 Out(integer level, string out)
 {
@@ -307,7 +308,7 @@ set_sittarget()
 
 update_current_anim_name()
 {
-    list SEQUENCE = llParseStringKeepNulls(CURRENT_ANIMATION_SEQUENCE, ["�"], []);
+    list SEQUENCE = llParseStringKeepNulls(CURRENT_ANIMATION_SEQUENCE, [SEP], []);
     CURRENT_ANIMATION_FILENAME = llList2String(SEQUENCE, SEQUENCE_POINTER);
     string speed_text = llList2String(["", "+", "-"], speed_index);
     if (llGetInventoryType(CURRENT_ANIMATION_FILENAME + speed_text) == INVENTORY_ANIMATION)
@@ -438,6 +439,7 @@ default
 {
     state_entry()
     {
+        // OSS::SEP = llUnescapeURL("%7F");
         SCRIPT_CHANNEL = (integer)llGetSubString(llGetScriptName(), llSubStringIndex(llGetScriptName(), " "), -1);
         while (llGetInventoryType(memoryscript) != INVENTORY_SCRIPT)
         {
@@ -472,7 +474,7 @@ default
     timer()
     {
         SEQUENCE_POINTER += 2;
-        list SEQUENCE = llParseStringKeepNulls(CURRENT_ANIMATION_SEQUENCE, ["�"], []);
+        list SEQUENCE = llParseStringKeepNulls(CURRENT_ANIMATION_SEQUENCE, [SEP], []);
         if (SEQUENCE_POINTER >= llGetListLength(SEQUENCE) || llListFindList(["M", "F"], llList2List(SEQUENCE, SEQUENCE_POINTER, SEQUENCE_POINTER)) != -1)
         {
             SEQUENCE_POINTER = 0;
@@ -1059,7 +1061,7 @@ default
                     llSetText("", <1,1,1>, 1);
                     llMessageLinked(LINK_SET, 90150, "", ""); // 90150=ask other AVsitA scripts to place their sittargets again
                 }
-                llMessageLinked(LINK_THIS, 90302, (string)SCRIPT_CHANNEL, llDumpList2String([llGetListLength(SITTERS), llDumpList2String(SITTER_INFO, "�"), SET, MTYPE, ETYPE, SWAP, FIRST_POSENAME, BRAND, CUSTOM_TEXT, llDumpList2String(ADJUST_MENU, "�"), SELECT, AMENU, OLD_HELPER_METHOD, RLVDesignations, onSit], "|")); // 90302=send notecard settings to AVsitB
+                llMessageLinked(LINK_THIS, 90302, (string)SCRIPT_CHANNEL, llDumpList2String([llGetListLength(SITTERS), llDumpList2String(SITTER_INFO, SEP), SET, MTYPE, ETYPE, SWAP, FIRST_POSENAME, BRAND, CUSTOM_TEXT, llDumpList2String(ADJUST_MENU, SEP), SELECT, AMENU, OLD_HELPER_METHOD, RLVDesignations, onSit], "|")); // 90302=send notecard settings to AVsitB
                 reused_variable = (llGetFreeMemory() - 5000) / 100;
                 return;
             }
@@ -1079,7 +1081,7 @@ default
             string part1;
             if (llGetListLength(parts) > 1)
             {
-                part1 = llStringTrim(llDumpList2String(llList2List(parts, 1, -1), "�"), STRING_TRIM);
+                part1 = llStringTrim(llDumpList2String(llList2List(parts, 1, -1), SEP), STRING_TRIM);
             }
             if (command == "SITTER")
             {

--- a/AVsitter2/[AV]sitB.lsl
+++ b/AVsitter2/[AV]sitB.lsl
@@ -48,6 +48,7 @@ string RLVDesignations;
 string onSit;
 integer speed_index;
 integer verbose = 0;
+string SEP = "�"; // OSS::string SEP;
 
 Out(integer level, string out)
 {
@@ -99,14 +100,14 @@ integer animation_menu(integer animation_menu_function)
         }
         if (SITTER_INFO != "")
         {
-            menu += "[" + llList2String(llParseStringKeepNulls(SITTER_INFO, ["�"], []), 0) + "]";
+            menu += "[" + llList2String(llParseStringKeepNulls(SITTER_INFO, [SEP], []), 0) + "]";
         }
         else if (number_of_sitters > 1)
         {
             menu += "[Sitter " + (string)SCRIPT_CHANNEL + "]";
         }
         integer anim_has_speeds;
-        string animation_file = llList2String(llParseStringKeepNulls(llList2String(DATA_LIST, ANIM_INDEX), ["�"], []), 0);
+        string animation_file = llList2String(llParseStringKeepNulls(llList2String(DATA_LIST, ANIM_INDEX), [SEP], []), 0);
         if (llGetInventoryType(animation_file + "+") == INVENTORY_ANIMATION)
         {
             anim_has_speeds = TRUE;
@@ -239,6 +240,7 @@ default
     state_entry()
     {
         memory();
+        // OSS::SEP = llUnescapeURL("%7F");
         SCRIPT_CHANNEL = (integer)llGetSubString(llGetScriptName(), llSubStringIndex(llGetScriptName(), " "), -1);
         if (SCRIPT_CHANNEL)
             main_script += " " + (string)SCRIPT_CHANNEL;
@@ -280,7 +282,7 @@ default
         index = llListFindList(MENU_LIST, ["B:" + msg]);
         if (index != -1)
         {
-            list button_data = llParseStringKeepNulls(llList2String(DATA_LIST, index), ["�"], []);
+            list button_data = llParseStringKeepNulls(llList2String(DATA_LIST, index), [SEP], []);
             if (llList2String(button_data, 1) != "")
             {
                 msg = llList2String(button_data, 1);

--- a/AVsitter2/build-aux.py
+++ b/AVsitter2/build-aux.py
@@ -48,10 +48,6 @@ def oss_process(filename):
         if filename is not None:
             f.close()
 
-    # The U+FFFD character that AVsitter uses causes problems in OpenSim.
-    # Replace it with U+001F (Unit Separator) which works fine.
-    s = s.replace(b'\xEF\xBF\xBD', b'\x1F')
-
     # UUIDs in OpenSim
     s = s.replace('f2e0ed5e-6592-4199-901d-a659c324ca94',
                   '206fcbe2-47b3-41e8-98e6-8909595b8605')


### PR DESCRIPTION
Use a global variable instead. In SL, the optimizer does the replacement automatically, therefore no memory penalty is incurred. In OpenSim, the variable is assigned at run time with llUnescapeURL. The OpenSim separator is also changed from U+001F to U+007F, because most control characters under U+0020 cause problems with exporting when present in script memory.

Fixes #41.

The only change betweeen #42 and this PR is the separator change suggested in #41.