### PR TITLE
Disable [BACK] button from [AV]root-security when not sat.

### DIFF
--- a/AVsitter2/[AV]root-security.lsl
+++ b/AVsitter2/[AV]root-security.lsl
@@ -102,7 +102,12 @@ register_touch(key id, integer animation_menu_function, integer active_prim, int
 
 main_menu()
 {
-    dialog("Sit access: " + llList2String(SIT_TYPES, SIT_INDEX) + "\nMenu access: " + llList2String(MENU_TYPES, MENU_INDEX) + "\n\nChange security settings:", ["[BACK]", "Sit", "Menu"]);
+    list buttons = (list)"Sit" + "Menu";
+    if (active_sitter) // OSS::if (osIsUUID(active_sitter) && active_sitter != NULL_KEY)
+    {
+        buttons = "[BACK]" + buttons;
+    }
+    dialog("Sit access: " + llList2String(SIT_TYPES, SIT_INDEX) + "\nMenu access: " + llList2String(MENU_TYPES, MENU_INDEX) + "\n\nChange security settings:", buttons);
     lastmenu = "";
 }
 


### PR DESCRIPTION
When no one is sitting, it's still possible to get a menu that has a [SECURITY] option, via RLV's ONTOUCH ASK. This breaks the assumption in the [BACK] button handler, which sent the [ADJUST] menu to an active sitter, and when there was no sitter, the menu was sent to all sitters instead, causing multiple dialogs to be generated. Repro details are in #35.

Fix by disabling the [BACK] button when no active sitter is set. The alternative of faking a click is not viable because we've lost the information of what prim was clicked, which is essential for RLV to know where to force-sit the victim.

Disabling [BACK] is a bit rude on the user, but it has the advantage that they have to click the desired prim again, therefore the information is recovered.

Fixes #35.

----

An alternative fix would be to disable the [SECURITY] menu in these circumstances, on the ground that they can always sit and reach it through the [ADJUST] menu. But this fix does not remove existing functionality, apart from the broken [BACK] button.