### PR TITLE
Allow AVpos-shifter to shift both position and rotation at a time

### DIFF
--- a/AVsitter2/Utilities/AVpos-shifter.lsl
+++ b/AVsitter2/Utilities/AVpos-shifter.lsl
@@ -143,8 +143,13 @@ default
             if (v != ZERO_VECTOR)
             {
                 llOwnerSay("Converting positions in " + notecard_name + " by offset: " + (string)v);
-                cut_above_text();
                 target_prim_pos = -v;
+                v = (vector)llList2String(llCSV2List(msg), 1);
+                if (v != ZERO_VECTOR)
+                {
+                    target_prim_rot = llEuler2Rot(v * DEG_TO_RAD);
+                }
+                cut_above_text();
                 notecard_query = llGetNotecardLine(notecard_name, notecard_line);
             }
             else

--- a/AVsitter2/Utilities/AVpos-shifter.lsl
+++ b/AVsitter2/Utilities/AVpos-shifter.lsl
@@ -189,7 +189,7 @@ default
             }
             else
             {
-                data = llStringTrim(llGetSubString(data, llSubStringIndex(data, "◆") + 1, -1), STRING_TRIM);
+                data = llStringTrim(llGetSubString(data, llSubStringIndex(data, "◆") + 1, 99999), STRING_TRIM);
                 if (llGetSubString(data, 0, 0) == "{")
                 {
                     string command = llStringTrim(llGetSubString(data, 1, llSubStringIndex(data, "}") - 1), STRING_TRIM);

--- a/AVsitter2/Utilities/AVpos-shifter.lsl
+++ b/AVsitter2/Utilities/AVpos-shifter.lsl
@@ -197,7 +197,7 @@ default
                     data = llGetSubString(data, llSubStringIndex(data, "}") + 1, -1);
                     list parts = llParseStringKeepNulls(data, ["<"], []);
                     vector pos = (vector)("<" + llList2String(parts, 1));
-                    pos = -target_prim_pos / target_prim_rot + pos / target_prim_rot;
+                    pos = (pos - target_prim_pos) / target_prim_rot;
                     rotation rot = llEuler2Rot((vector)("<" + llList2String(parts, 2)) * DEG_TO_RAD);
                     vector vec_rot = llRot2Euler(rot / target_prim_rot) * RAD_TO_DEG;
                     string result = "<" + FormatFloat(pos.x, 3) + "," + FormatFloat(pos.y, 3) + "," + FormatFloat(pos.z, 3) + ">";
@@ -222,7 +222,7 @@ default
                     {
                         pos = (vector)llList2String(parts, index);
                         rot = llEuler2Rot((vector)llList2String(parts, index + 1) * DEG_TO_RAD);
-                        pos = -target_prim_pos / target_prim_rot + pos / target_prim_rot;
+                        pos = (pos - target_prim_pos) / target_prim_rot;
                         vector vec_rot = llRot2Euler(rot / target_prim_rot) * RAD_TO_DEG;
                         string pos_string = "<" + FormatFloat(pos.x, 3) + "," + FormatFloat(pos.y, 3) + "," + FormatFloat(pos.z, 3) + ">";
                         string rot_string = "<" + FormatFloat(vec_rot.x, 1) + "," + FormatFloat(vec_rot.y, 1) + "," + FormatFloat(vec_rot.z, 1) + ">";

--- a/AVsitter2/Utilities/AVpos-shifter.lsl
+++ b/AVsitter2/Utilities/AVpos-shifter.lsl
@@ -68,7 +68,7 @@ string FormatFloat(float f, integer num_decimals)
 
 instructions()
 {
-    llOwnerSay("\n\nINSTRUCTIONS:\n\nFOR MOVING ALL POSE & PROP POSITIONS BY AN OFFSET:\nManual Position: specify a position offset on channel 5, and positions will be converted by that offset. E.g. /5 <0,0,1.5>\nManual Rotation: specify a rotation offset on channel 6 (in degrees), and rotations will be converted by that offset, relative to the prim center. E.g. /6 <0,0,180>\n\nFOR RELOCATING SCRIPTS TO NEW PRIM:\n1. Unlink your object and re-link so that the prim you want to move the animations from is the root prim, then place this script inside the root prim.\n2. Touch the prim you want to locate the poses to. This prim should be empty or contain a script with llPassTouches(TRUE);\n3. The script will read out the notecard in chat, with pos/rot modified to the prim you touched.\n\nHave Fun! :)\n");
+    llOwnerSay("\n\nINSTRUCTIONS:\n\nFOR MOVING ALL POSE & PROP POSITIONS BY AN OFFSET:\nManual Position: specify a position offset on channel 5, and positions will be converted by that offset. E.g. /5 <0,0,1.5>\nManual Rotation: specify a rotation offset on channel 6 (in degrees), and rotations will be converted by that offset, relative to the prim center. E.g. /6 <0,0,180>\nBoth Position and Rotation: Enter /5 <position>,<rotation> (there's a comma between both). E.g. /5 <0,0,1.5>,<0,0,180>\n\nFOR RELOCATING SCRIPTS TO NEW PRIM:\n1. Unlink your object and re-link so that the prim you want to move the animations from is the root prim, then place this script inside the root prim.\n2. Touch the prim you want to locate the poses to. This prim should be empty or contain a script with llPassTouches(TRUE);\n3. The script will read out the notecard in chat, with pos/rot modified to the prim you touched.\n\nHave Fun! :)\n");
 }
 
 cut_above_text()
@@ -147,6 +147,7 @@ default
                 v = (vector)llList2String(llCSV2List(msg), 1);
                 if (v != ZERO_VECTOR)
                 {
+                    llOwnerSay("Converting rotations in " + notecard_name + " by offset: " + (string)v);
                     target_prim_rot = llEuler2Rot(v * DEG_TO_RAD);
                 }
                 cut_above_text();


### PR DESCRIPTION
Suggested in the group. The new function is equivalent to applying position and rotation in that order.

It also fixes a minor annoyance with diamonds.