### PR TITLE
Fix [AV]faces issue with the timer not being stopped.

### DIFF
--- a/AVsitter2/Plugins/AVfaces/[AV]faces.lsl
+++ b/AVsitter2/Plugins/AVfaces/[AV]faces.lsl
@@ -241,6 +241,9 @@ default
     on_rez(integer start)
     {
         is_running = TRUE;
+        // cancel all sequences as there can't be anyone sitting
+        while (running_uuid != [])
+            remove_sequences(llList2Key(running_uuid, 0));
     }
 
     link_message(integer sender, integer num, string msg, key id)


### PR DESCRIPTION
The problem has been observed in some items using [AV]faces.

So far the only way I've found to reproduce it was resetting one of the [AV]sit scripts while [AV]faces was reproducing a sequence. Other triggers may be possible.

At some point I assumed it was because of taking the item while sitting on it. That doesn't seem to be the case.