### PR TITLE
Fix several calls that had wraparound hazards.

### DIFF
--- a/AVsitter2/Plugins/AVcamera/[AV]camera.lsl
+++ b/AVsitter2/Plugins/AVcamera/[AV]camera.lsl
@@ -107,7 +107,7 @@ default
 
     state_entry()
     {
-        SCRIPT_CHANNEL = (integer)llGetSubString(llGetScriptName(), llSubStringIndex(llGetScriptName(), " "), -1);
+        SCRIPT_CHANNEL = (integer)llGetSubString(llGetScriptName(), llSubStringIndex(llGetScriptName(), " "), 99999);
         notecard_key = llGetInventoryKey(notecard_name);
         if (llGetInventoryType(notecard_name) == INVENTORY_NOTECARD)
         {
@@ -223,10 +223,10 @@ default
             }
             else
             {
-                data = llGetSubString(data, llSubStringIndex(data, "◆") + 1, -1);
+                data = llGetSubString(data, llSubStringIndex(data, "◆") + 1, 99999);
                 data = llStringTrim(data, STRING_TRIM);
                 string command = llGetSubString(data, 0, llSubStringIndex(data, " ") - 1);
-                list parts = llParseStringKeepNulls(llGetSubString(data, llSubStringIndex(data, " ") + 1, -1), [" | ", " |", "| ", "|"], []);
+                list parts = llParseStringKeepNulls(llGetSubString(data, llSubStringIndex(data, " ") + 1, 99999), [" | ", " |", "| ", "|"], []);
                 string part0 = llStringTrim(llList2String(parts, 0), STRING_TRIM);
                 if (command == "SITTER")
                 {
@@ -234,7 +234,7 @@ default
                 }
                 else if (notecard_section == SCRIPT_CHANNEL && command == "CAMERA")
                 {
-                    string part1 = llStringTrim(llDumpList2String(llList2List(parts, 1, -1), "|"), STRING_TRIM);
+                    string part1 = llStringTrim(llDumpList2String(llList2List(parts, 1, 99999), "|"), STRING_TRIM);
                     list sequence = llParseString2List(part1, ["|"], []);
                     camera_triggers += part0;
                     camera_settings += part1;

--- a/AVsitter2/Plugins/AVcontrol/Xcite!-Sensations/[AV]Xcite!.lsl
+++ b/AVsitter2/Plugins/AVcontrol/Xcite!-Sensations/[AV]Xcite!.lsl
@@ -175,7 +175,7 @@ default
             {
                 data = llStringTrim(data, STRING_TRIM);
                 string command = llGetSubString(data, 0, llSubStringIndex(data, " ") - 1);
-                list parts = llParseStringKeepNulls(llGetSubString(data, llSubStringIndex(data, " ") + 1, -1), [" | ", " |", "| ", "|"], []);
+                list parts = llParseStringKeepNulls(llGetSubString(data, llSubStringIndex(data, " ") + 1, 99999), [" | ", " |", "| ", "|"], []);
                 if (command == "TIMER")
                 {
                     TIMER_DEFAULT = llList2Integer(parts, 0);

--- a/AVsitter2/Plugins/AVcontrol/[AV]root-RLV.lsl
+++ b/AVsitter2/Plugins/AVcontrol/[AV]root-RLV.lsl
@@ -1207,7 +1207,7 @@ state running
             {
                 data = llStringTrim(data, STRING_TRIM);
                 string command = llGetSubString(data, 0, llSubStringIndex(data, " ") - 1);
-                list parts = llParseStringKeepNulls(llGetSubString(data, llSubStringIndex(data, " ") + 1, -1), [" | ", " |", "| ", "|"], []);
+                list parts = llParseStringKeepNulls(llGetSubString(data, llSubStringIndex(data, " ") + 1, 99999), [" | ", " |", "| ", "|"], []);
                 string part0 = llStringTrim(llList2String(parts, 0), STRING_TRIM);
                 part0 = llGetSubString(part0, 0, 22);
                 if (command == "WAITPOSE")

--- a/AVsitter2/Plugins/AVfaces/[AV]faces.lsl
+++ b/AVsitter2/Plugins/AVfaces/[AV]faces.lsl
@@ -86,7 +86,7 @@ Readout_Say(string say, string SCRIPT_CHANNEL)
 
 string Key2Number(key objKey)
 {
-    return llGetSubString((string)llAbs((integer)("0x" + llGetSubString((string)objKey, -8, -1)) & 1073741823 ^ -1073741825), 6, -1);
+    return llGetSubString((string)llAbs((integer)("0x" + llGetSubString((string)objKey, -8, -1)) & 0x3FFFFFFF ^ 0xBFFFFFFF), 6, 99999);
 }
 
 init_sitters()
@@ -414,10 +414,10 @@ default
             }
             else
             {
-                data = llGetSubString(data, llSubStringIndex(data, "◆") + 1, -1);
+                data = llGetSubString(data, llSubStringIndex(data, "◆") + 1, 99999);
                 data = llStringTrim(data, STRING_TRIM);
                 string command = llGetSubString(data, 0, llSubStringIndex(data, " ") - 1);
-                list parts = llParseStringKeepNulls(llGetSubString(data, llSubStringIndex(data, " ") + 1, -1), [" | ", " |", "| ", "|"], []);
+                list parts = llParseStringKeepNulls(llGetSubString(data, llSubStringIndex(data, " ") + 1, 99999), [" | ", " |", "| ", "|"], []);
                 if (command == "SITTER")
                 {
                     notecard_section = llList2Integer(parts, 0);

--- a/AVsitter2/Plugins/AVprop/[AV]menu.lsl
+++ b/AVsitter2/Plugins/AVprop/[AV]menu.lsl
@@ -267,7 +267,7 @@ integer prop_menu(integer return_pages, key av)
             }
             else
             {
-                menu_items1 += llGetSubString(llList2String(llParseString2List(llList2String(MENU_LIST, i), ["|"], []), 0), 2, -1);
+                menu_items1 += llGetSubString(llList2String(llParseString2List(llList2String(MENU_LIST, i), ["|"], []), 0), 2, 99999);
             }
         }
     }
@@ -587,15 +587,15 @@ default
             }
             else
             {
-                data = llGetSubString(data, llSubStringIndex(data, "◆") + 1, -1);
+                data = llGetSubString(data, llSubStringIndex(data, "◆") + 1, 99999);
                 data = llStringTrim(data, STRING_TRIM);
                 string command = llGetSubString(data, 0, llSubStringIndex(data, " ") - 1);
-                list parts = llParseStringKeepNulls(llGetSubString(data, llSubStringIndex(data, " ") + 1, -1), [" | ", " |", "| ", "|"], []);
+                list parts = llParseStringKeepNulls(llGetSubString(data, llSubStringIndex(data, " ") + 1, 99999), [" | ", " |", "| ", "|"], []);
                 string part0 = llStringTrim(llList2String(parts, 0), STRING_TRIM);
                 string part1 = llList2String(parts, 1);
                 if (llGetListLength(parts) > 1)
                 {
-                    part1 = llStringTrim(llDumpList2String(llList2List(parts, 1, -1), SEP), STRING_TRIM);
+                    part1 = llStringTrim(llDumpList2String(llList2List(parts, 1, 99999), SEP), STRING_TRIM);
                 }
                 if (command == "TEXT")
                 {

--- a/AVsitter2/Plugins/AVprop/[AV]prop.lsl
+++ b/AVsitter2/Plugins/AVprop/[AV]prop.lsl
@@ -376,7 +376,7 @@ default
                     {
                         if (llList2Key(SITTERS, i) == sitting_av_or_sitter || id == "" || (string)sitting_av_or_sitter == (string)i)
                         {
-                            remove_sitter_props_by_pose((string)i + "|" + llGetSubString(msg, 8, -1), TRUE);
+                            remove_sitter_props_by_pose((string)i + "|" + llGetSubString(msg, 8, 99999), TRUE);
                         }
                     }
                 }
@@ -601,10 +601,10 @@ default
                 return;
             }
 
-            data = llGetSubString(data, llSubStringIndex(data, "◆") + 1, -1);
+            data = llGetSubString(data, llSubStringIndex(data, "◆") + 1, 99999);
             data = llStringTrim(data, STRING_TRIM);
             string command = llGetSubString(data, 0, llSubStringIndex(data, " ") - 1);
-            list parts = llParseStringKeepNulls(llGetSubString(data, llSubStringIndex(data, " ") + 1, -1), [" | ", " |", "| ", "|"], []);
+            list parts = llParseStringKeepNulls(llGetSubString(data, llSubStringIndex(data, " ") + 1, 99999), [" | ", " |", "| ", "|"], []);
             if (command == "SITTER")
             {
                 notecard_section = (integer)llList2String(parts, 0);

--- a/AVsitter2/Plugins/AVsequence/[AV]sequence.lsl
+++ b/AVsitter2/Plugins/AVsequence/[AV]sequence.lsl
@@ -267,7 +267,7 @@ default
             {
                 list datalist = llParseString2List(data, [" "], []);
                 string command = llList2String(datalist, 0);
-                data = llStringTrim(llDumpList2String(llList2List(datalist, 1, -1), " "), STRING_TRIM);
+                data = llStringTrim(llDumpList2String(llList2List(datalist, 1, 99999), " "), STRING_TRIM);
                 list commands = ["PLAY", "WAIT", "SAY", "WHISPER", "SOUND", "LOOP"];
                 if (command == "DEBUG")
                 {

--- a/AVsitter2/Utilities/AVpos-shifter.lsl
+++ b/AVsitter2/Utilities/AVpos-shifter.lsl
@@ -194,7 +194,7 @@ default
                 {
                     string command = llStringTrim(llGetSubString(data, 1, llSubStringIndex(data, "}") - 1), STRING_TRIM);
                     data = llDumpList2String(llParseString2List(data, [" "], [""]), "");
-                    data = llGetSubString(data, llSubStringIndex(data, "}") + 1, -1);
+                    data = llGetSubString(data, llSubStringIndex(data, "}") + 1, 99999);
                     list parts = llParseStringKeepNulls(data, ["<"], []);
                     vector pos = (vector)("<" + llList2String(parts, 1));
                     pos = (pos - target_prim_pos) / target_prim_rot;

--- a/AVsitter2/Utilities/MLP-converter.lsl
+++ b/AVsitter2/Utilities/MLP-converter.lsl
@@ -145,7 +145,7 @@ default
                 if (llGetSubString(notecard_name, 0, 9) == ".MENUITEMS")
                 {
                     string command = llGetSubString(data, 0, llSubStringIndex(data, " ") - 1);
-                    list parts = llParseString2List(llGetSubString(data, llSubStringIndex(data, " ") + 1, -1), [" | ", " |", "| ", "|"], []);
+                    list parts = llParseString2List(llGetSubString(data, llSubStringIndex(data, " ") + 1, 99999), [" | ", " |", "| ", "|"], []);
                     if (command == "TOMENU" || command == "MENU")
                     {
                     }

--- a/AVsitter2/Utilities/Missing-anim-finder.lsl
+++ b/AVsitter2/Utilities/Missing-anim-finder.lsl
@@ -83,10 +83,10 @@ default
             }
             else
             {
-                data = llGetSubString(data, llSubStringIndex(data, "◆") + 1, -1);
+                data = llGetSubString(data, llSubStringIndex(data, "◆") + 1, 99999);
                 data = llStringTrim(data, STRING_TRIM);
                 string command = llGetSubString(data, 0, llSubStringIndex(data, " ") - 1);
-                list parts = llParseString2List(llGetSubString(data, llSubStringIndex(data, " ") + 1, -1), [" | ", " |", "| ", "|"], []);
+                list parts = llParseString2List(llGetSubString(data, llSubStringIndex(data, " ") + 1, 99999), [" | ", " |", "| ", "|"], []);
                 if (command == "POSE" || command == "SYNC")
                 {
                     list anims = llList2ListStrided(llDeleteSubList(parts, 0, 0), 0, -1, 2);

--- a/AVsitter2/Utilities/Updater/update-sender.lsl
+++ b/AVsitter2/Utilities/Updater/update-sender.lsl
@@ -72,7 +72,7 @@ default
     {
         llSetTimerEvent(0);
         llListenRemove(listenhandle);
-        state do_update;        
+        state do_update;
     }
 
     touch_start(integer touched)
@@ -109,7 +109,7 @@ default
                 if (distance <= mysize.x / 2)
                 {
                     objects_to_update += id;
-                    objects_files += llDumpList2String(llList2List(data, 1, -1), "|");
+                    objects_files += llDumpList2String(llList2List(data, 1, 99999), "|");
                 }
             }
         }
@@ -124,11 +124,11 @@ state do_update
         i = 0;
         llSetTimerEvent(0.1);
     }
-    
+
     timer(){
 
         llRegionSayTo(av, 0, "Processing prim " + (string)(i+1) + "/" + (string)llGetListLength(objects_to_update));
-       	
+
         key object = llList2Key(objects_to_update, i);
         list items = llParseStringKeepNulls(llList2String(objects_files, i), ["|"], []);
         if (1 == 1)
@@ -196,10 +196,10 @@ state do_update
                 }
             }
         }
-        
+
         i++;
 
-        if(i==llGetListLength(objects_to_update)){        
+        if(i==llGetListLength(objects_to_update)){
             llRegionSayTo(av, 0, "Updates complete!");
             llResetScript();
         }

--- a/AVsitter2/[AV]adjuster.lsl
+++ b/AVsitter2/[AV]adjuster.lsl
@@ -525,7 +525,7 @@ default
                 else if (llGetSubString(msg, 0, 0) == "{")
                 {
                     msg = strReplace(msg, "{P:", "{");
-                    list parts = llParseStringKeepNulls(llDumpList2String(llParseString2List(llGetSubString(msg, llSubStringIndex(msg, "}") + 1, -1), [" "], [""]), ""), ["<"], []);
+                    list parts = llParseStringKeepNulls(llDumpList2String(llParseString2List(llGetSubString(msg, llSubStringIndex(msg, "}") + 1, 99999), [" "], [""]), ""), ["<"], []);
                     vector pos2 = (vector)("<" + llList2String(parts, 1));
                     vector rot2 = (vector)("<" + llList2String(parts, 2));
                     string result = "<" + FormatFloat(pos2.x, 3) + "," + FormatFloat(pos2.y, 3) + "," + FormatFloat(pos2.z, 3) + ">";
@@ -595,7 +595,7 @@ default
                             if (llSubStringIndex(llList2String(SITTER_POSES, i), "P:") == 0)
                             {
                                 type = "POSE";
-                                temp_pose_name = llGetSubString(temp_pose_name, 2, -1);
+                                temp_pose_name = llGetSubString(temp_pose_name, 2, 99999);
                             }
                             llMessageLinked(LINK_THIS, 90301, (string)i, llList2String(SITTER_POSES, i) + "|" + llList2String(POS_LIST, i) + "|" + llList2String(ROT_LIST, i) + "|");
                             vector pos = llList2Vector(POS_LIST, i);
@@ -908,7 +908,7 @@ default
             }
             else if (OLD_HELPER_METHOD)
             {
-                integer sitter = (integer)llGetSubString(name, llSubStringIndex(name, " ") + 1, -1);
+                integer sitter = (integer)llGetSubString(name, llSubStringIndex(name, " ") + 1, 99999);
                 if (llList2String(data, 0) == "ANIMA")
                 {
                     llMessageLinked(LINK_THIS, 90075, (string)sitter, llList2Key(data, 1));

--- a/AVsitter2/[AV]select.lsl
+++ b/AVsitter2/[AV]select.lsl
@@ -192,10 +192,10 @@ default
             }
             else
             {
-                data = llGetSubString(data, llSubStringIndex(data, "◆") + 1, -1);
+                data = llGetSubString(data, llSubStringIndex(data, "◆") + 1, 99999);
                 data = llStringTrim(data, STRING_TRIM);
                 string command = llGetSubString(data, 0, llSubStringIndex(data, " ") - 1);
-                list parts = llParseString2List(llGetSubString(data, llSubStringIndex(data, " ") + 1, -1), [" | ", " |", "| ", "|"], []);
+                list parts = llParseString2List(llGetSubString(data, llSubStringIndex(data, " ") + 1, 99999), [" | ", " |", "| ", "|"], []);
                 string part0 = llList2String(parts, 0);
                 if (command == "TEXT")
                 {

--- a/AVsitter2/[AV]sitA.lsl
+++ b/AVsitter2/[AV]sitA.lsl
@@ -219,7 +219,7 @@ sittargets()
         {
             integer next = llListFindList(SITTERS_SITTARGETS, [1000]);
             string desc = (string)llGetLinkPrimitiveParams(i, [PRIM_DESC]);
-            desc = llGetSubString(desc, llSubStringIndex(desc, "#") + 1, -1);
+            desc = llGetSubString(desc, llSubStringIndex(desc, "#") + 1, 99999);
             if (desc != "-1")
             {
                 list data = llParseStringKeepNulls(desc, ["-"], []);
@@ -362,7 +362,7 @@ apply_current_anim(integer broadcast)
                 }
                 else
                 {
-                    POSENAME = llGetSubString(POSENAME, 2, -1);
+                    POSENAME = llGetSubString(POSENAME, 2, 99999);
                 }
                 string OLD_SYNC;
                 if (OLD_POSE_NAME != CURRENT_POSE_NAME)
@@ -452,7 +452,7 @@ default
 {
     state_entry()
     {
-        SCRIPT_CHANNEL = (integer)llGetSubString(llGetScriptName(), llSubStringIndex(llGetScriptName(), " "), -1);
+        SCRIPT_CHANNEL = (integer)llGetSubString(llGetScriptName(), llSubStringIndex(llGetScriptName(), " "), 99999);
         while (llGetInventoryType(memoryscript) != INVENTORY_SCRIPT)
         {
             llSleep(0.1);
@@ -1103,7 +1103,7 @@ default
             string posename = CURRENT_POSE_NAME;
             if (llGetSubString(CURRENT_POSE_NAME, 0, 1) == "P:")
             {
-                posename = llGetSubString(CURRENT_POSE_NAME, 2, -1);
+                posename = llGetSubString(CURRENT_POSE_NAME, 2, 99999);
             }
             llMessageLinked(LINK_THIS, 90070, (string)SCRIPT_CHANNEL, MY_SITTER); // 90070=update SITTERS after permissions granted
             llMessageLinked(LINK_THIS, lnk, posename, channel_or_swap);
@@ -1155,15 +1155,15 @@ default
             // Request next line
             notecard_query = llGetNotecardLine(notecard_name, ++reused_variable);
 
-            data = llGetSubString(data, llSubStringIndex(data, "◆") + 1, -1);
+            data = llGetSubString(data, llSubStringIndex(data, "◆") + 1, 99999);
             data = llStringTrim(data, STRING_TRIM_HEAD);
             string command = llGetSubString(data, 0, llSubStringIndex(data, " ") - 1);
-            list parts = llParseStringKeepNulls(llGetSubString(data, llSubStringIndex(data, " ") + 1, -1), [" | ", " |", "| ", "|"], []);
+            list parts = llParseStringKeepNulls(llGetSubString(data, llSubStringIndex(data, " ") + 1, 99999), [" | ", " |", "| ", "|"], []);
             string part0 = llStringTrim(llList2String(parts, 0), STRING_TRIM);
             string part1;
             if (llGetListLength(parts) > 1)
             {
-                part1 = llStringTrim(llDumpList2String(llList2List(parts, 1, -1), SEP), STRING_TRIM);
+                part1 = llStringTrim(llDumpList2String(llList2List(parts, 1, 99999), SEP), STRING_TRIM);
             }
             if (command == "SITTER")
             {
@@ -1185,7 +1185,7 @@ default
                     reading_notecard_section = TRUE;
                     if (llGetListLength(parts) > 1)
                     {
-                        SITTER_INFO = llList2List(parts, 1, -1);
+                        SITTER_INFO = llList2List(parts, 1, 99999);
                     }
                 }
                 return;
@@ -1280,7 +1280,7 @@ default
                 if (llGetSubString(data, 0, 0) == "{")
                 {
                     command = llStringTrim(llGetSubString(data, 1, llSubStringIndex(data, "}") - 1), STRING_TRIM);
-                    parts = llParseStringKeepNulls(llDumpList2String(llParseString2List(llGetSubString(data, llSubStringIndex(data, "}") + 1, -1), [" "], [""]), ""), ["<"], []);
+                    parts = llParseStringKeepNulls(llDumpList2String(llParseString2List(llGetSubString(data, llSubStringIndex(data, "}") + 1, 99999), [" "], [""]), ""), ["<"], []);
                     string pos = "<" + llList2String(parts, 1);
                     string rot = "<" + llList2String(parts, 2);
                     if (command == FIRST_POSENAME || "P:" + command == FIRST_POSENAME)

--- a/AVsitter2/[AV]sitB.lsl
+++ b/AVsitter2/[AV]sitB.lsl
@@ -191,7 +191,7 @@ integer animation_menu(integer animation_menu_function)
                 }
                 else
                 {
-                    menu_items1 += llGetSubString(m, 2, -1);
+                    menu_items1 += llGetSubString(m, 2, 99999);
                 }
             }
         }
@@ -225,7 +225,7 @@ default
     state_entry()
     {
         memory();
-        SCRIPT_CHANNEL = (integer)llGetSubString(llGetScriptName(), llSubStringIndex(llGetScriptName(), " "), -1);
+        SCRIPT_CHANNEL = (integer)llGetSubString(llGetScriptName(), llSubStringIndex(llGetScriptName(), " "), 99999);
         if (SCRIPT_CHANNEL)
             main_script += " " + (string)SCRIPT_CHANNEL;
         if (llGetInventoryType(main_script) == INVENTORY_SCRIPT)
@@ -321,7 +321,7 @@ default
                 }
                 else
                 {
-                    current_menu = llListFindList(MENU_LIST, ["T:" + llGetSubString(llList2String(MENU_LIST, current_menu), 2, -1)]);
+                    current_menu = llListFindList(MENU_LIST, ["T:" + llGetSubString(llList2String(MENU_LIST, current_menu), 2, 99999)]);
                     if (current_menu != -1)
                     {
                         current_menu -= 1;


### PR DESCRIPTION
`llGetSubString("abc", 3, -1)` gives `"abc"`; `llList2List(L, 1, -1)` gives L when L has length 1. In general, `llGetSubString` or `llList2List` return the whole thing when the starting index is grater than the last element in the list.

There were a number of spots with that hazard, so fix all we found.