### PR TITLE
Add the script name at the top, with a one-line description

### DIFF
--- a/AVsitter2/Plugins/AVcamera/[AV]camera.lsl
+++ b/AVsitter2/Plugins/AVcamera/[AV]camera.lsl
@@ -1,4 +1,6 @@
 /*
+ * [AV]camera - Set pose-specific camera settings
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/AVsitter2/Plugins/AVcontrol/LockGuard/[AV]LockGuard-object.lsl
+++ b/AVsitter2/Plugins/AVcontrol/LockGuard/[AV]LockGuard-object.lsl
@@ -1,4 +1,6 @@
- /*
+/*
+ * [AV]LockGuard-object - Allows props to be used as chain targets.
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/AVsitter2/Plugins/AVcontrol/LockGuard/[AV]LockGuard.lsl
+++ b/AVsitter2/Plugins/AVcontrol/LockGuard/[AV]LockGuard.lsl
@@ -1,4 +1,6 @@
- /*
+/*
+ * [AV]LockGuard - Attach LockGuard V2 chains
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/AVsitter2/Plugins/AVcontrol/Xcite!-Sensations/[AV]Xcite!.lsl
+++ b/AVsitter2/Plugins/AVcontrol/Xcite!-Sensations/[AV]Xcite!.lsl
@@ -1,4 +1,6 @@
 /*
+ * [AV]Xcite! - Allows working with Xcite!™ and Sensations products
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -12,7 +14,7 @@
  * instructions can be found at http://avsitter.github.io
  */
 
-string product = "AVsitter™ Xcite!";
+string product = "AVsitter™ Xcite!™";
 string version = "1.02";
 string notecard_name = "[AV]Xcite_settings";
 key notecard_key;

--- a/AVsitter2/Plugins/AVcontrol/[AV]root-RLV-extra.lsl
+++ b/AVsitter2/Plugins/AVcontrol/[AV]root-RLV-extra.lsl
@@ -1,4 +1,6 @@
 /*
+ * [AV]root-RLV-extra - Additional features for the RLV plugin
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/AVsitter2/Plugins/AVcontrol/[AV]root-RLV.lsl
+++ b/AVsitter2/Plugins/AVcontrol/[AV]root-RLV.lsl
@@ -1,4 +1,6 @@
 /*
+ * [AV]root-RLV - RLV plugin for AVsitter
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/AVsitter2/Plugins/AVcontrol/[AV]root-control.lsl
+++ b/AVsitter2/Plugins/AVcontrol/[AV]root-control.lsl
@@ -1,4 +1,6 @@
 /*
+ * [AV]root-control - Allow others to control the menu
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/AVsitter2/Plugins/AVfaces/[AV]faces.lsl
+++ b/AVsitter2/Plugins/AVfaces/[AV]faces.lsl
@@ -1,4 +1,6 @@
 /*
+ * [AV]faces - Use facial expressions in poses
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/AVsitter2/Plugins/AVprop/[AV]menu.lsl
+++ b/AVsitter2/Plugins/AVprop/[AV]menu.lsl
@@ -1,4 +1,6 @@
 /*
+ * [AV]menu - Allow using props without using sitting scripts.
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/AVsitter2/Plugins/AVprop/[AV]object.lsl
+++ b/AVsitter2/Plugins/AVprop/[AV]object.lsl
@@ -1,4 +1,6 @@
 /*
+ * [AV]object - Used in props for attaching, derezzing, etc.
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/AVsitter2/Plugins/AVprop/[AV]prop.lsl
+++ b/AVsitter2/Plugins/AVprop/[AV]prop.lsl
@@ -1,4 +1,6 @@
 /*
+ * [AV]prop - Rez props when playing poses
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/AVsitter2/Plugins/AVsequence/[AV]sequence.lsl
+++ b/AVsitter2/Plugins/AVsequence/[AV]sequence.lsl
@@ -1,4 +1,6 @@
 /*
+ * [AV]sequence - Play sequences of poses.
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/AVsitter2/Utilities/AVpos-generator.lsl
+++ b/AVsitter2/Utilities/AVpos-generator.lsl
@@ -1,4 +1,6 @@
 /*
+ * AVpos-generator - Generate a series of POSE lines from the contents
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/AVsitter2/Utilities/AVpos-shifter.lsl
+++ b/AVsitter2/Utilities/AVpos-shifter.lsl
@@ -1,4 +1,6 @@
 /*
+ * AVpos-shifter - Shifts positions and rotations of poses
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/AVsitter2/Utilities/Anim-perm-checker.lsl
+++ b/AVsitter2/Utilities/Anim-perm-checker.lsl
@@ -1,4 +1,6 @@
 /*
+ * Anim-perm-checker - Check permissions of animations
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/AVsitter2/Utilities/MLP-converter.lsl
+++ b/AVsitter2/Utilities/MLP-converter.lsl
@@ -1,4 +1,6 @@
 /*
+ * MLP-converter - Convert MLP version 2 notecards to AVsitter format
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/AVsitter2/Utilities/Missing-anim-finder.lsl
+++ b/AVsitter2/Utilities/Missing-anim-finder.lsl
@@ -1,4 +1,6 @@
 /*
+ * Missing-anim-finder - Finds missing or unused animations
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/AVsitter2/Utilities/Noob-detector.lsl
+++ b/AVsitter2/Utilities/Noob-detector.lsl
@@ -1,4 +1,6 @@
 /*
+ * Noob-detector - Make a report about an AVsitter setup
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/AVsitter2/Utilities/Updater/update-receiver.lsl
+++ b/AVsitter2/Utilities/Updater/update-receiver.lsl
@@ -1,4 +1,6 @@
 /*
+ * update-receiver - Allows remote updating of object contents.
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/AVsitter2/Utilities/Updater/update-sender.lsl
+++ b/AVsitter2/Utilities/Updater/update-sender.lsl
@@ -1,4 +1,6 @@
 /*
+ * update-sender - Send contents to an item with update-receiver
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -72,7 +74,7 @@ default
     {
         llSetTimerEvent(0);
         llListenRemove(listenhandle);
-        state do_update;        
+        state do_update;
     }
 
     touch_start(integer touched)
@@ -124,11 +126,11 @@ state do_update
         i = 0;
         llSetTimerEvent(0.1);
     }
-    
+
     timer(){
 
         llRegionSayTo(av, 0, "Processing prim " + (string)(i+1) + "/" + (string)llGetListLength(objects_to_update));
-       	
+
         key object = llList2Key(objects_to_update, i);
         list items = llParseStringKeepNulls(llList2String(objects_files, i), ["|"], []);
         if (1 == 1)
@@ -196,10 +198,10 @@ state do_update
                 }
             }
         }
-        
+
         i++;
 
-        if(i==llGetListLength(objects_to_update)){        
+        if(i==llGetListLength(objects_to_update)){
             llRegionSayTo(av, 0, "Updates complete!");
             llResetScript();
         }

--- a/AVsitter2/[AV]adjuster.lsl
+++ b/AVsitter2/[AV]adjuster.lsl
@@ -1,4 +1,6 @@
 /*
+ * [AV]adjuster - Create a setup and an AVpos notecard from scratch
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/AVsitter2/[AV]helper.lsl
+++ b/AVsitter2/[AV]helper.lsl
@@ -1,4 +1,6 @@
 /*
+ * [AV]helper - Setup aid, to move poses by moving an object
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/AVsitter2/[AV]root-security.lsl
+++ b/AVsitter2/[AV]root-security.lsl
@@ -1,4 +1,6 @@
 /*
+ * [AV]root-security - Specify who can sit and/or use the menu
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/AVsitter2/[AV]root.lsl
+++ b/AVsitter2/[AV]root.lsl
@@ -1,4 +1,6 @@
 /*
+ * [AV]root - Activate setups in child prims by touching the root
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/AVsitter2/[AV]select.lsl
+++ b/AVsitter2/[AV]select.lsl
@@ -1,4 +1,6 @@
 /*
+ * [AV]select - Allow choosing specific seats rather than using [SWAP]
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/AVsitter2/[AV]sitA.lsl
+++ b/AVsitter2/[AV]sitA.lsl
@@ -1,4 +1,6 @@
 /*
+ * [AV]sitA - Main sitting script - needs [AV]sitB to work
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/AVsitter2/[AV]sitB.lsl
+++ b/AVsitter2/[AV]sitB.lsl
@@ -1,4 +1,6 @@
 /*
+ * [AV]sitB - Main Memory script - needs [AV]sitA to work
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.


### PR DESCRIPTION
It should help ensuring that you have the right script contents when saving. It also provides a short description, to get a rough idea of what it's about.

The only code change is the product name in [AV]xcite! to add a TM symbol to Xcite!