### PR TITLE
Allow overriding of flags on invocation of make

### DIFF
--- a/AVsitter2/Makefile
+++ b/AVsitter2/Makefile
@@ -80,7 +80,7 @@ $(SLZIP): $(OPTIMIZED) $(UNOPTIMIZED)
 	$(ZIP) $@ $(OPTIMIZED) $(UNOPTIMIZED)
 
 %.lslo %.lslt: %.lsl
-	$(PYTHON) $(OPTIMIZER) -H -O addstrings,shrinknames,-extendedglobalexpr -p $(PREPROC_KIND) --precmd=$(PREPROC_PATH) $< -o $@
+	$(PYTHON) $(OPTIMIZER) -H -O addstrings,shrinknames,-extendedglobalexpr -p $(PREPROC_KIND) --precmd=$(PREPROC_PATH) $(OFLAGS) $< -o $@
 
 $(OSZIP): $(OPENSIM)
 	$(PYTHON) build-aux.py rm $@


### PR DESCRIPTION
For example, make OFLAGS="-O -ShrinkNames" would disable the ShrinkNames optimization.