### PR TITLE
Add ONSIT CAPIFSUB option to capture only if sitter is a sub

### DIFF
--- a/AVsitter2/Plugins/AVcontrol/[AV]root-RLV.lsl
+++ b/AVsitter2/Plugins/AVcontrol/[AV]root-RLV.lsl
@@ -364,7 +364,7 @@ new_controller(key id)
     CONTROLLER = id;
     controllerName = llKey2Name(CONTROLLER);
     llListenRemove(menu_handle);
-    menu_handle = llListen(menu_channel = ((integer)llFrand(0x7FFFFF80) + 1) * -1, "", CONTROLLER, ""); // 7FFFFF80 = max float < 2^31
+    menu_handle = llListen((menu_channel = ((integer)llFrand(0x7FFFFF80) + 1) * -1), "", CONTROLLER, ""); // 7FFFFF80 = max float < 2^31
 }
 
 no_sensor_results()

--- a/AVsitter2/Plugins/AVcontrol/[AV]root-RLV.lsl
+++ b/AVsitter2/Plugins/AVcontrol/[AV]root-RLV.lsl
@@ -437,7 +437,7 @@ find_seat(key id, integer index, string msg, integer captureSub)
 {
     if (index != -1)
     {
-        if (msg == Dominant_name)
+        if (msg == Dominant_name || msg == "D")
             msg = "D";
         else
             msg = "S";
@@ -682,6 +682,9 @@ state running
         {
             menu = "";
             SITTING_AVATARS += id;
+            // If they must be assigned a SUB spot, regardless of the
+            // automatically assigned sitter, lock them as they sit.
+            // That happens with ONSIT CAPTURE and with force-sitting.
             if (onSit == "CAPTURE" || (string)CONTROLLER + (string)id == PairWhoStartedCapture)
             {
                 if (llListFindList(DESIGNATIONS_NOW, ["S"]) != -1)
@@ -689,18 +692,21 @@ state running
                     find_seat(id, one, Submissive_name, TRUE);
                 }
             }
-            else if (onSit == "ASK")
+        }
+        else if (num == 90070)
+        {
+            // This is the first message where we know the sitter number
+            if (llListFindList(DESIGNATIONS_NOW, [id]) == -1)
             {
-                ask_role(id);
-            }
-            else
-            {
-                two = llListFindList(DESIGNATIONS_NOW, ["S"]);
-                if (llGetInventoryType(main_script + " 1") == INVENTORY_SCRIPT)
+                if (onSit == "CAPIFSUB")
                 {
-                    two = one;
+                    find_seat(id, one, llList2String(DESIGNATIONS_NOW, one), TRUE);
                 }
-                if (two != -1)
+                else if (onSit == "ASK")
+                {
+                    ask_role(id);
+                }
+                else if (onSit == "NONE")
                 {
                     DESIGNATIONS_NOW = llListReplaceList(DESIGNATIONS_NOW, [id], one, one);
                 }

--- a/AVsitter2/Plugins/AVcontrol/[AV]root-RLV.lsl
+++ b/AVsitter2/Plugins/AVcontrol/[AV]root-RLV.lsl
@@ -456,7 +456,7 @@ find_seat(key id, integer index, string msg, integer captureSub)
             {
                 playpose(DOMPOSE, (string)first_available);
             }
-            else if (msg == "S")
+            else //if (msg == "S") // assumed
             {
                 if (captureSub)
                 {
@@ -635,12 +635,13 @@ state running
 
     link_message(integer sender, integer num, string msg, key id)
     {
+        integer one = (integer)msg;
+        integer two;
         if (num == 90030)
         {
             if (!ignorenextswap)
             {
-                integer one = (integer)msg;
-                integer two = (integer)((string)id);
+                two = (integer)((string)id);
                 key des1 = llList2String(DESIGNATIONS_NOW, one);
                 key des2 = llList2String(DESIGNATIONS_NOW, two);
                 string role1 = llList2String(SITTER_DESIGNATIONS_MASTER, one);
@@ -685,7 +686,7 @@ state running
             {
                 if (llListFindList(DESIGNATIONS_NOW, ["S"]) != -1)
                 {
-                    find_seat(id, (integer)msg, Submissive_name, TRUE);
+                    find_seat(id, one, Submissive_name, TRUE);
                 }
             }
             else if (onSit == "ASK")
@@ -694,14 +695,14 @@ state running
             }
             else
             {
-                integer index = llListFindList(DESIGNATIONS_NOW, ["S"]);
+                two = llListFindList(DESIGNATIONS_NOW, ["S"]);
                 if (llGetInventoryType(main_script + " 1") == INVENTORY_SCRIPT)
                 {
-                    index = (integer)msg;
+                    two = one;
                 }
-                if (index != -1)
+                if (two != -1)
                 {
-                    DESIGNATIONS_NOW = llListReplaceList(DESIGNATIONS_NOW, [id], (integer)msg, (integer)msg);
+                    DESIGNATIONS_NOW = llListReplaceList(DESIGNATIONS_NOW, [id], one, one);
                 }
             }
         }


### PR DESCRIPTION
ONSIT CAPTURE captures subs first and when all the sub places are filled, the next avatar to sit will be a Dom.

The new ONSIT CAPIFSUB respects AVsitter's sitter number choice (whether it is sequential, by gender, by targeted sitting or whatever) but if the role assigned to that seat is a sub one, it additionally captures the avatar.

Fixes #59.