### PR TITLE
Fix distinguishing BUTTON by submenu

### DIFF
--- a/AVsitter2/[AV]sitB.lsl
+++ b/AVsitter2/[AV]sitB.lsl
@@ -265,7 +265,8 @@ default
             animation_menu(0);
             return;
         }
-        index = llListFindList(MENU_LIST, ["B:" + msg]);
+        index = llListFindList(llList2List(MENU_LIST, current_menu, 99999), ["B:" + msg]);
+        if (index != -1) index += current_menu;
         if (index != -1)
         {
             list button_data = llParseStringKeepNulls(llList2String(DATA_LIST, index), [SEP], []);


### PR DESCRIPTION
When the same BUTTON appears in different submenus, with different parameters, pressing it always picked the one that appeared first in the notecard.

Fix that by making the search start at the current menu.

Per bug report by AceyXx.