### PR TITLE
resolve #75, fixes #77

### DIFF
--- a/AVsitter2/Plugins/AVprop/[AV]menu.lsl
+++ b/AVsitter2/Plugins/AVprop/[AV]menu.lsl
@@ -137,7 +137,6 @@ menu_check(string name, key id, string msg, integer menu_function)
             {
                 menu_page = 0;
                 current_menu = index;
-                msg = "";
             }         
             avmenu(FALSE, id);
         }

--- a/AVsitter2/Plugins/AVprop/[AV]menu.lsl
+++ b/AVsitter2/Plugins/AVprop/[AV]menu.lsl
@@ -119,7 +119,7 @@ integer prim_is_mod()
     return 0;
 }
 
-menu_check(string name, key id)
+menu_check(string name, key id, string msg, integer menu_function)
 {
     if (pass_security(id) == TRUE)
     {
@@ -127,9 +127,19 @@ menu_check(string name, key id)
         {
             last_menu_unixtime = llGetUnixTime();
             last_menu_avatar = name;
-            menu_page = 0;
-            current_menu = -1;
-            prop_menu(FALSE, id);
+            integer index = llListFindList(MENU_LIST, ["M:" + msg + "*"]);
+            if (menu_function == 90004 || (name != last_menu_avatar && index == -1))
+            {
+            	menu_page = 0;
+                current_menu = -1;
+            }
+            else if (index != -1)
+            {
+                menu_page = 0;
+                current_menu = index;
+                msg = "";
+            }         
+            avmenu(FALSE, id);
         }
         else
         {
@@ -228,7 +238,7 @@ remove_script(string reason)
     llRemoveInventory(llGetScriptName());
 }
 
-integer prop_menu(integer return_pages, key av)
+integer avmenu(integer return_pages, key av)
 {
     choosing = FALSE;
     choice = "";
@@ -419,18 +429,18 @@ default
                     menu_page--;
                     if (menu_page < 0)
                     {
-                        menu_page = prop_menu(TRUE, NULL_KEY);
+                        menu_page = avmenu(TRUE, NULL_KEY);
                     }
                 }
                 else
                 {
                     menu_page++;
-                    if (menu_page > prop_menu(TRUE, NULL_KEY))
+                    if (menu_page > avmenu(TRUE, NULL_KEY))
                     {
                         menu_page = 0;
                     }
                 }
-                prop_menu(FALSE, id);
+                avmenu(FALSE, id);
             }
             return;
         }
@@ -530,14 +540,14 @@ default
             {
             }
         }
-        prop_menu(FALSE, id);
+        avmenu(FALSE, id);
     }
 
     touch_start(integer touched)
     {
         if (MTYPE < 3)
         {
-            menu_check(llDetectedName(0), llDetectedKey(0));
+            menu_check(llDetectedName(0), llDetectedKey(0), "", 90004);
         }
     }
 
@@ -557,9 +567,9 @@ default
     {
         if (sender == llGetLinkNumber())
         {
-            if (num == 90005) // send menu to id
+            if (num == 90004 || num == 90005) // send menu to id
             {
-                menu_check(llKey2Name(id), id);
+                menu_check(llKey2Name(id), id, msg, num);
             }
             else if (num == 90022) // send dump to [AV]adjuster
             {


### PR DESCRIPTION
Includes the following changes: 
* Allows use of [90004](https://avsitter.github.io/avsitter2_scripting.html#message-90004) in AVmenu, to specify the TOP level of the menu.
* Allows opening specific submenu by name by including the name as the string sent with 90004/90005 link messages (addresses #75).
* Fix for #77: 90005 brings up the LAST menu used (unless a specific submenu is requested or a different avatar is using it).
* Renamed the function ```prop_menu``` to ```avmenu```.
