### PR TITLE
Fix [AV]select menu

### DIFF
--- a/AVsitter2/[AV]sitA.lsl
+++ b/AVsitter2/[AV]sitA.lsl
@@ -67,7 +67,7 @@ key notecard_key;
 key notecard_query;
 integer reading_notecard_section;
 integer notecard_lines;
-string reused_key;
+key reused_key;
 integer reused_variable;
 integer my_sittarget;
 integer original_my_sittarget;
@@ -177,8 +177,7 @@ wipe_sit_targets()
     integer i;
     for (; i <= llGetNumberOfPrims(); i++)
     {
-        string desc = (string)llGetLinkPrimitiveParams(i, [PRIM_DESC]);
-        if (desc != "-1" && llGetSubString(desc, -3, -1) != "#-1")
+        if ((string)llGetLinkPrimitiveParams(i, [PRIM_DESC]) != "-1")
         {
             llLinkSitTarget(i, ZERO_VECTOR, ZERO_ROTATION);
         }
@@ -316,8 +315,7 @@ set_sittarget()
     {
         target = 0;
     }
-    reused_key = (string)llGetLinkPrimitiveParams(target, [PRIM_DESC]);
-    if (reused_key != "-1" && llGetSubString(reused_key, -3, -1) != "#-1")
+    if ((string)llGetLinkPrimitiveParams(target, [PRIM_DESC]) != "-1")
     {
         llLinkSitTarget(target, target_pos - <0.,0.,0.4> + llRot2Up(target_rot) * 0.05, target_rot);
     }
@@ -479,8 +477,7 @@ default
             // wipe_sit_targets() inlined here:
             for (i = 0; i <= llGetNumberOfPrims(); i++)
             {
-                reused_key = (string)llGetLinkPrimitiveParams(i, [PRIM_DESC]);
-                if (reused_key != "-1" && llGetSubString(reused_key, -3, -1) != "#-1")
+                if ((string)llGetLinkPrimitiveParams(i, [PRIM_DESC]) != "-1")
                 {
                     llLinkSitTarget(i, ZERO_VECTOR, ZERO_ROTATION);
                 }
@@ -684,12 +681,12 @@ default
             if (one == SCRIPT_CHANNEL || two == SCRIPT_CHANNEL)
             {
                 end_sitter();
-                reused_key = llList2String(SITTERS, one);
+                reused_key = llList2Key(SITTERS, one);
                 if (one == SCRIPT_CHANNEL)
                 {
-                    reused_key = llList2String(SITTERS, two);
+                    reused_key = llList2Key(SITTERS, two);
                 }
-                if ((key)reused_key) // OSS::if (osIsUUID(reused_key) && reused_key != NULL_KEY)
+                if (reused_key) // OSS::if (osIsUUID(reused_key) && reused_key != NULL_KEY)
                 {
                     SWAPPED = TRUE;
                     llRequestPermissions(reused_key, PERMISSION_TRIGGER_ANIMATION);
@@ -1049,8 +1046,7 @@ default
                     // wipe_sit_targets() inlined here:
                     for (i = 0; i <= llGetNumberOfPrims(); i++)
                     {
-                        reused_key = (string)llGetLinkPrimitiveParams(i, [PRIM_DESC]);
-                        if (reused_key != "-1" && llGetSubString(reused_key, -3, -1) != "#-1")
+                        if ((string)llGetLinkPrimitiveParams(i, [PRIM_DESC]) != "-1")
                         {
                             llLinkSitTarget(i, ZERO_VECTOR, ZERO_ROTATION);
                         }

--- a/AVsitter2/[AV]sitA.lsl
+++ b/AVsitter2/[AV]sitA.lsl
@@ -177,7 +177,8 @@ wipe_sit_targets()
     integer i;
     for (; i <= llGetNumberOfPrims(); i++)
     {
-        if ((string)llGetLinkPrimitiveParams(i, [PRIM_DESC]) != "-1")
+        string desc = (string)llGetLinkPrimitiveParams(i, [PRIM_DESC]);
+        if (desc != "-1" && "#-1" != llGetSubString(desc, -3, -1))
         {
             llLinkSitTarget(i, ZERO_VECTOR, ZERO_ROTATION);
         }
@@ -315,7 +316,8 @@ set_sittarget()
     {
         target = 0;
     }
-    if ((string)llGetLinkPrimitiveParams(target, [PRIM_DESC]) != "-1")
+    string desc = (string)llGetLinkPrimitiveParams(target, [PRIM_DESC]);
+    if (desc != "-1" && "#-1" != llGetSubString(desc, -3, -1))
     {
         llLinkSitTarget(target, target_pos - <0.,0.,0.4> + llRot2Up(target_rot) * 0.05, target_rot);
     }
@@ -477,7 +479,8 @@ default
             // wipe_sit_targets() inlined here:
             for (i = 0; i <= llGetNumberOfPrims(); i++)
             {
-                if ((string)llGetLinkPrimitiveParams(i, [PRIM_DESC]) != "-1")
+                string desc = (string)llGetLinkPrimitiveParams(i, [PRIM_DESC]);
+                if (desc != "-1" && "#-1" != llGetSubString(desc, -3, -1))
                 {
                     llLinkSitTarget(i, ZERO_VECTOR, ZERO_ROTATION);
                 }
@@ -1046,7 +1049,8 @@ default
                     // wipe_sit_targets() inlined here:
                     for (i = 0; i <= llGetNumberOfPrims(); i++)
                     {
-                        if ((string)llGetLinkPrimitiveParams(i, [PRIM_DESC]) != "-1")
+                        string desc = (string)llGetLinkPrimitiveParams(i, [PRIM_DESC]);
+                        if (desc != "-1" && "#-1" != llGetSubString(desc, -3, -1))
                         {
                             llLinkSitTarget(i, ZERO_VECTOR, ZERO_ROTATION);
                         }


### PR DESCRIPTION
The previous fix for #66 introduced a bug due to the `reused_key` global being corrupted when `run_time_permissions` was executed. One visible effect was that [AV]select would always re-show the sitter selection menu and never progress to the poses menu. Revert that and write a fix that uses locals.

Per report by Pearce Kingsley, with diagnosing help from Pearce Kingsley and Kyra Ishtari.

Note: The failing commit was the last one in the 2.2-03 tag. Taking advantage of that, version 2.2-03.01 was branched from the commit immediately preceding it. This fix is submitted to master as a PR, so that it can wait for the other PRs to be resolved.