### PR TITLE
Fix warning when the initial connection to the database fails

### DIFF
--- a/php/settings.php
+++ b/php/settings.php
@@ -31,7 +31,7 @@ ini_set('display_errors', '1');
 
 require_once("settings-config.inc.php");
 
-$link = mysqli_connect($dbhost, $dbuser, $dbpass, $dbname) or die("Error " . mysqli_error($link));
+$link = mysqli_connect($dbhost, $dbuser, $dbpass, $dbname);
 
 if (mysqli_connect_errno()) {
     die ("Connect failed: " . mysqli_connect_error());


### PR DESCRIPTION
When `mysqli_connect` fails, `$link` becomes false, and the `or` branch is taken, which uses `mysqli_error($link)`, which in turn fails because $link is false.

Since it's correctly checking `mysqli_connect_errno()` in the next line, just removing the `or` suffices.

Per report by jonhboy Resident.