### PR TITLE
Fix BUTTON link message

### DIFF
--- a/AVsitter2/[AV]sitB.lsl
+++ b/AVsitter2/[AV]sitB.lsl
@@ -265,10 +265,10 @@ default
             animation_menu(0);
             return;
         }
-        index = llListFindList(llList2List(MENU_LIST, current_menu, 99999), ["B:" + msg]);
-        if (index != -1) index += current_menu;
+        index = llListFindList(llList2List(MENU_LIST, current_menu + 1, 99999), ["B:" + msg]);
         if (index != -1)
         {
+            index += current_menu + 1;
             list button_data = llParseStringKeepNulls(llList2String(DATA_LIST, index), [SEP], []);
             if (llList2String(button_data, 1) != "")
             {


### PR DESCRIPTION
Follow-up to a65d7cd, which failed for the main menu. That's because current_menu is -1 for the main menu.

Since current menu is either -1 or points to a MENU entry, it's safe to add 1 to it and bring it to a correct range.

While on it, remove redundant `if`.

Per bug report by RiderDavis.

Fixes #95.