### PR TITLE
Adjustments needed in AVcontrol plugin for OpenSim

### DIFF
--- a/AVsitter2/Plugins/AVcontrol/[AV]root-RLV-extra.lsl
+++ b/AVsitter2/Plugins/AVcontrol/[AV]root-RLV-extra.lsl
@@ -174,8 +174,10 @@ state running
             product = llList2String(data, 2);
             llListenRemove(menu_handle);
             llListenRemove(GETSTATUShandle);
-            menu_handle = llListen(menu_channel = ((integer)llFrand(0x7FFFFF80) + 1) * -1, "", CONTROLLER, ""); // 7FFFFF80 = max float < 2^31
-            GETSTATUShandle = llListen(RELAY_GETSTATUS_CHANNEL = (integer)llFrand(999999936), "", "", ""); // 999999936 = max float < 1e9
+            menu_channel = ((integer)llFrand(0x7FFFFF80) + 1) * -1;
+            menu_handle = llListen(menu_channel, "", CONTROLLER, ""); // 7FFFFF80 = max float < 2^31
+            RELAY_GETSTATUS_CHANNEL = (integer)llFrand(999999936);
+            GETSTATUShandle = llListen(RELAY_GETSTATUS_CHANNEL, "", "", ""); // 999999936 = max float < 1e9
             if (num == 90208)
             {
                 main_menu();

--- a/AVsitter2/Plugins/AVcontrol/[AV]root-control.lsl
+++ b/AVsitter2/Plugins/AVcontrol/[AV]root-control.lsl
@@ -114,7 +114,8 @@ controller_menu(key id)
 dialog(string text, list menu_items, key id)
 {
     llListenRemove(menu_handle);
-    menu_handle = llListen(menu_channel = ((integer)llFrand(0x7FFFFF80) + 1) * -1, "", id, ""); // 7FFFFF80 = max float < 2^31
+    menu_channel = ((integer)llFrand(0x7FFFFF80) + 1) * -1;
+    menu_handle = llListen(menu_channel, "", id, ""); // 7FFFFF80 = max float < 2^31
     llDialog(id, product + " " + version + "\n\n" + text + "\n", order_buttons(menu_items), menu_channel);
     llSetTimerEvent(120);
 }

--- a/AVsitter2/Plugins/AVprop/[AV]menu.lsl
+++ b/AVsitter2/Plugins/AVprop/[AV]menu.lsl
@@ -137,7 +137,6 @@ menu_check(string name, key id, string msg, integer menu_function)
             {
                 menu_page = 0;
                 current_menu = index;
-                msg = "";
             }         
             avmenu(FALSE, id);
         }

--- a/AVsitter2/Plugins/AVprop/[AV]menu.lsl
+++ b/AVsitter2/Plugins/AVprop/[AV]menu.lsl
@@ -119,7 +119,7 @@ integer prim_is_mod()
     return 0;
 }
 
-menu_check(string name, key id)
+menu_check(string name, key id, string msg, integer menu_function)
 {
     if (pass_security(id) == TRUE)
     {
@@ -127,9 +127,19 @@ menu_check(string name, key id)
         {
             last_menu_unixtime = llGetUnixTime();
             last_menu_avatar = name;
-            menu_page = 0;
-            current_menu = -1;
-            prop_menu(FALSE, id);
+            integer index = llListFindList(MENU_LIST, ["M:" + msg + "*"]);
+            if (menu_function == 90004 || (name != last_menu_avatar && index == -1))
+            {
+            	menu_page = 0;
+                current_menu = -1;
+            }
+            else if (index != -1)
+            {
+                menu_page = 0;
+                current_menu = index;
+                msg = "";
+            }         
+            avmenu(FALSE, id);
         }
         else
         {
@@ -228,7 +238,7 @@ remove_script(string reason)
     llRemoveInventory(llGetScriptName());
 }
 
-integer prop_menu(integer return_pages, key av)
+integer avmenu(integer return_pages, key av)
 {
     choosing = FALSE;
     choice = "";
@@ -419,18 +429,18 @@ default
                     menu_page--;
                     if (menu_page < 0)
                     {
-                        menu_page = prop_menu(TRUE, NULL_KEY);
+                        menu_page = avmenu(TRUE, NULL_KEY);
                     }
                 }
                 else
                 {
                     menu_page++;
-                    if (menu_page > prop_menu(TRUE, NULL_KEY))
+                    if (menu_page > avmenu(TRUE, NULL_KEY))
                     {
                         menu_page = 0;
                     }
                 }
-                prop_menu(FALSE, id);
+                avmenu(FALSE, id);
             }
             return;
         }
@@ -530,14 +540,14 @@ default
             {
             }
         }
-        prop_menu(FALSE, id);
+        avmenu(FALSE, id);
     }
 
     touch_start(integer touched)
     {
         if (MTYPE < 3)
         {
-            menu_check(llDetectedName(0), llDetectedKey(0));
+            menu_check(llDetectedName(0), llDetectedKey(0), "", 90004);
         }
     }
 
@@ -557,9 +567,9 @@ default
     {
         if (sender == llGetLinkNumber())
         {
-            if (num == 90005) // send menu to id
+            if (num == 90004 || num == 90005) // send menu to id
             {
-                menu_check(llKey2Name(id), id);
+                menu_check(llKey2Name(id), id, msg, num);
             }
             else if (num == 90022) // send dump to [AV]adjuster
             {


### PR DESCRIPTION
A few minor adjustments needed to make these acceptable on OpenSim's XEngine.
you only need commit 5eb99570134d7f3bbbd7f743a4146fefcb8793d4.
Just another info: my fork OpenSim/Arriba supports AVsitter since May 2018.