### PR TITLE
Allow passing single IDs when calling external scripts

### DIFF
--- a/AVsitter2/[AV]sitA.lsl
+++ b/AVsitter2/[AV]sitA.lsl
@@ -541,7 +541,7 @@ default
         integer index = llListFindList(ADJUST_MENU, [msg]);
         if (index != -1)
         {
-            if (id != MY_SITTER)
+            if (id != MY_SITTER && !(AMENU & 4))
             {
                 id = (string)id + "|" + (string)MY_SITTER;
             }
@@ -1149,7 +1149,7 @@ default
                     llSetText("", <1,1,1>, 1);
                     llMessageLinked(LINK_SET, 90150, "", ""); // 90150=ask other AVsitA scripts to place their sittargets again
                 }
-                llMessageLinked(LINK_THIS, 90302, (string)SCRIPT_CHANNEL, llDumpList2String([llGetListLength(SITTERS), llDumpList2String(SITTER_INFO, SEP), SET, MTYPE, ETYPE, SWAP, FIRST_POSENAME, BRAND, CUSTOM_TEXT, llDumpList2String(ADJUST_MENU, SEP), SELECT, AMENU, OLD_HELPER_METHOD, RLVDesignations, onSit], "|")); // 90302=send notecard settings to AVsitB
+                llMessageLinked(LINK_THIS, 90302, (string)SCRIPT_CHANNEL, llDumpList2String([llGetListLength(SITTERS), llDumpList2String(SITTER_INFO, SEP), SET, MTYPE, ETYPE, SWAP, FIRST_POSENAME, BRAND, CUSTOM_TEXT, llDumpList2String(ADJUST_MENU, SEP), SELECT, AMENU & 3, OLD_HELPER_METHOD, RLVDesignations, onSit], "|")); // 90302=send notecard settings to AVsitB
                 reused_variable = (llGetFreeMemory() - 5000) / 100;
                 return;
             }

--- a/AVsitter2/[AV]sitB.lsl
+++ b/AVsitter2/[AV]sitB.lsl
@@ -278,6 +278,10 @@ default
             if (llGetListLength(button_data) > 2)
             {
                 id = llList2String(button_data, 2);
+                if (id == "<C>")
+                    id = CONTROLLER;
+                if (id == "<S>")
+                    id = MY_SITTER;
             }
             else if (CONTROLLER != MY_SITTER)
             {


### PR DESCRIPTION
BUTTON is documented to pass the UUIDs of the controller *and* the sitter when they are different, separated by a `|`.

ADJUST is not documented to do that (yet), but it behaves that way.

Both behaviours are undesirable for generic scripts that respond to a link message without being specifically designed for AVsitter, because they don't expect the extra UUID. This can be seen as an AVsitter shortcoming, therefore we implement backwards-compatible workarounds.

For ADJUST, the AMENU argument's range has been extended:

- 0, 1 and 2 behave the same as before.
- 4, 5 and 6 behave as 0, 1 and 2 respectively, but also inhibit sending the second UUID.

For BUTTON, two special values have been added for the ID field: `<C>` and `<S>`, which will be replaced with CONTROLLER and SITTER respectively. For example:

    BUTTON text|num|str

behaves the same as before, sending both CONTROLLER and SITTER in the UUID field when they differ; however:

    BUTTON text|num|str|<C>

always passes only the UUID of the person who controls the menu. Similarly for `<S>`.