### PR TITLE
Add plugin to allow animesh dummies to "sit"

### DIFF
--- a/AVsitter2/Plugins/AVdummy/[AV]dummy.lsl
+++ b/AVsitter2/Plugins/AVdummy/[AV]dummy.lsl
@@ -1,0 +1,328 @@
+/*
+ * [AV]dummy - Reference animesh dummy implementation
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright © the AVsitter Contributors (http://avsitter.github.io)
+ * AVsitter™ is a trademark. For trademark use policy see:
+ * https://avsitter.github.io/TRADEMARK.mediawiki
+ *
+ * Please consider supporting continued development of AVsitter and
+ * receive automatic updates and other benefits! All details and user
+ * instructions can be found at http://avsitter.github.io
+ */
+
+integer SITTERS_MAY_CONTROL = TRUE;
+integer GENDER = 0;
+
+// offset that's needed to make the dummy face forward, might be different for different models?
+vector FWD = <0, 1, 0>;
+vector LEFT = <-1, 0, 0>;
+vector UP = <0, 0, 1>;
+rotation NEUTRAL_ROT;
+
+// anims that are internal to the dummy, and shouldn't be removed, stopped or counted by the anim hashing
+// (deformers, etc.)
+list INTERNAL_ANIMS = [];
+
+integer AV2_ANIMESH_CHANNEL = -1252168;
+integer DIALOG_CHANNEL = -6246233;
+
+integer CONN_STATE_DISCONNECTED = 0;
+integer CONN_STATE_DISCOVERY = 1;
+integer CONN_STATE_CHOOSING = 2;
+integer CONN_STATE_WAITING = 3;
+integer CONN_STATE_CONNECTED = 4;
+integer gConnState;
+
+key gTargetFurniture = NULL_KEY;
+
+string gAnimsHash;
+integer gInventoryDirtied;
+
+list gReceivedNames = [];
+list gReceivedKeys = [];
+list gReceivedHashes = [];
+
+string truncateDialogButton(string text) {
+    return llBase64ToString(llGetSubString(llStringToBase64(text), 0, 31));
+}
+
+integer mayControlMenu(key id) {
+    if (id == llGetOwner())
+        return TRUE;
+    if (gFurnitureKey != NULL_KEY && SITTERS_MAY_CONTROL)
+        // TODO: get SITTERS from anim broadcast and use that?
+        return llList2Key(llGetObjectDetails(id, [OBJECT_ROOT]), 0) == gFurnitureKey;
+    return FALSE;
+}
+
+setStatusText(string text) {
+    llSetLinkPrimitiveParamsFast(LINK_ROOT, [PRIM_TEXT, text, <1,1,1>, 1]);
+}
+
+clearOldAnims() {
+    integer i = llGetInventoryNumber(INVENTORY_ANIMATION);
+    while(i-- > 0) {
+        string name = llGetInventoryName(INVENTORY_ANIMATION, i);
+        if (llListFindList(INTERNAL_ANIMS, [name]) == -1)
+            llRemoveInventory(name);
+    }
+}
+
+recalcAnimsHash() {
+    integer num = llGetInventoryNumber(INVENTORY_ANIMATION);
+    integer i;
+    gAnimsHash = "";
+    for(i=0; i<num; ++i) {
+        string name = llGetInventoryName(INVENTORY_ANIMATION, i);
+        if (llListFindList(INTERNAL_ANIMS, [name]) == -1)
+            gAnimsHash = llSHA1String(name + gAnimsHash);
+    }
+}
+
+stopAllAnims(integer internal_anims) {
+    integer i;
+    list anims = llGetObjectAnimationNames();
+    integer len = llGetListLength(anims);
+    for(i=0; i<len; ++i) {
+        string name = llList2String(anims, i);
+        if (!internal_anims)
+            if (llListFindList(INTERNAL_ANIMS, [name]) != -1)
+                jump next;
+        llStopObjectAnimation(llList2String(anims, i));
+        @next;
+    }
+}
+
+setConnState(integer state_) {
+    // clear any queued up timer events
+    llSetTimerEvent(0.0);
+
+    if (state_ != CONN_STATE_CHOOSING) {
+        gReceivedKeys = [];
+        gReceivedNames = [];
+        gReceivedHashes = [];
+    }
+
+    if (state_ != CONN_STATE_WAITING && state_ != CONN_STATE_CONNECTED) {
+        // Tell the connected furniture that we're disconnecting, if we have one
+        sendCmd("DISCONNECT");
+        gTargetFurniture = NULL_KEY;
+    }
+
+    if (state_ == CONN_STATE_DISCONNECTED) {
+        llSetTimerEvent(10.0);
+        setStatusText("Disconnected");
+        stopAllAnims(FALSE);
+        llStartObjectAnimation("stand");
+        llSetLinkPrimitiveParamsFast(LINK_ROOT, [PRIM_ROTATION, NEUTRAL_ROT]);
+    } else if (state_ == CONN_STATE_DISCOVERY) {
+        setStatusText("Scanning for furniture...");
+        llSetTimerEvent(2.0);
+    } else if (state_ == CONN_STATE_CHOOSING) {
+        setStatusText("Waiting for selection...");
+        llSetTimerEvent(20.0);
+    } else if (state_ == CONN_STATE_WAITING) {
+        setStatusText("Waiting for furniture to accept");
+        llSetTimerEvent(10.0);
+    } else if (state_ == CONN_STATE_CONNECTED) {
+        setStatusText("");
+        llStopObjectAnimation("stand");
+        llSetTimerEvent(5.0);
+    } else {
+        llOwnerSay("Asked to change to unknown state????");
+        setConnState(CONN_STATE_DISCONNECTED);
+    }
+
+    // Set this here so we can compare old state to new state above
+    // if needed
+    gConnState = state_;
+}
+
+handleFurnitureMsg(key id, string msg) {
+    list params = llParseStringKeepNulls(msg, ["|"], []);
+    string cmd = llList2String(params, 0);
+    params = llList2List(params, 1, -1);
+
+    if (gConnState == CONN_STATE_DISCONNECTED) {
+        // Furniture asked us to connect
+        if (cmd == "SOLICIT") {
+            if (gTargetFurniture == NULL_KEY && llGetOwnerKey(id) == llGetOwner()) {
+                connectToFurniture(id, llList2String(params, 0));
+            }
+        }
+    // while we're looking for furniture to connect to
+    } else if (gConnState == CONN_STATE_DISCOVERY) {
+        if (cmd == "DISCOVERY_PONG") {
+            // furniture told us it exists
+            if (llGetOwnerKey(id) != llGetOwner())
+                return;
+
+            if (llGetListLength(gReceivedKeys) >= 9) {
+                return;
+            }
+
+            if (llListFindList(gReceivedKeys, [id]) == -1) {
+                gReceivedKeys += id;
+                gReceivedNames += truncateDialogButton(llList2String(params, 0));
+                gReceivedHashes += llList2String(params, 1);
+            }
+        }
+    // while we're talking to specific furniture
+    } else if (id == gTargetFurniture) {
+        if (gConnState == CONN_STATE_CONNECTED) {
+            if (cmd == "DISCONNECT") {
+                setConnState(CONN_STATE_DISCONNECTED);
+                return;
+            } else if (cmd == "START_ANIM") {
+                llStartObjectAnimation(llList2String(params, 0));
+            } else if (cmd == "STOP_ANIM") {
+                llStopObjectAnimation(llList2String(params, 0));
+            } else if (cmd == "REPOSITION") {
+                list root_params = llGetObjectDetails(gTargetFurniture, [OBJECT_POS, OBJECT_ROT]);
+                vector root_pos = llList2Vector(root_params, 0);
+                rotation root_rot = llList2Rot(root_params, 1);
+
+                llSetLinkPrimitiveParamsFast(LINK_ROOT, [
+                    PRIM_POSITION, root_pos + ((vector)llList2String(params, 0) * root_rot),
+                    // TODO: is this right? Seems ok.
+                    PRIM_ROTATION, NEUTRAL_ROT * (rotation)llList2String(params, 1) * root_rot
+                ]);
+            }
+        } else {
+            if (cmd == "CONNECT_RESP") {
+                string msg = llList2String(params, 0);
+                if (msg) {
+                    llOwnerSay("Couldn't connect due to '" + msg + "'");
+                    setConnState(CONN_STATE_DISCONNECTED);
+                } else {
+                    llOwnerSay("Furniture connected");
+                    setConnState(CONN_STATE_CONNECTED);
+                }
+            }
+        }
+    }
+}
+
+sendCmd(string msg) {
+    if (gTargetFurniture != NULL_KEY) {
+        llRegionSayTo(gTargetFurniture, AV2_ANIMESH_CHANNEL, msg);
+    }
+}
+
+connectToFurniture(key id, string anims_hash) {
+    // recalc our anim hash if we need to
+    if (gInventoryDirtied) {
+        gInventoryDirtied = FALSE;
+        recalcAnimsHash();
+    }
+    integer need_anims = gAnimsHash != anims_hash;
+    llOwnerSay(gAnimsHash + " : " + anims_hash);
+    if (need_anims) {
+        setStatusText("Removing old animations");
+        clearOldAnims();
+    }
+
+    gTargetFurniture = id;
+
+    setConnState(CONN_STATE_WAITING);
+    sendCmd("CONNECT|" + (string)GENDER + "|" + (string)need_anims);
+}
+
+default {
+    state_entry() {
+        NEUTRAL_ROT = llAxes2Rot(FWD, LEFT, UP);
+        setConnState(CONN_STATE_DISCONNECTED);
+        llListen(AV2_ANIMESH_CHANNEL, "", "", "");
+        llListen(DIALOG_CHANNEL, "", "", "");
+        // Let any dangling doodads know we disconnected
+        llWhisper(AV2_ANIMESH_CHANNEL, "DISCONNECT");
+        recalcAnimsHash();
+    }
+
+    on_rez(integer start_param) {
+        setConnState(CONN_STATE_DISCONNECTED);
+    }
+
+    touch_start(integer total_number) {
+        integer i;
+        for (i = 0; i < total_number; ++i) {
+            key id = llDetectedKey(i);
+            if(gConnState == CONN_STATE_DISCONNECTED) {
+                if (id == llGetOwner()) {
+                    llWhisper(AV2_ANIMESH_CHANNEL, "DISCOVERY_PING");
+                    setConnState(CONN_STATE_DISCOVERY);
+                }
+            } else if (gConnState == CONN_STATE_CONNECTED) {
+                if (mayControlMenu(id))
+                    sendCmd("SHOW_MENU|" + id);
+            }
+        }
+    }
+
+    listen (integer channel, string name, key id, string msg) {
+        key owner_key = llGetOwnerKey(id);
+        if (channel == DIALOG_CHANNEL) {
+            if (gConnState == CONN_STATE_CHOOSING) {
+                if (owner_key != llGetOwner()) {
+                    return;
+                }
+                integer key_idx = llListFindList(gReceivedNames, [msg]);
+                if (key_idx == -1) {
+                    llOwnerSay("I don't know what " + msg + " is");
+                    setConnState(CONN_STATE_DISCONNECTED);
+                    return;
+                }
+
+                connectToFurniture(
+                    llList2Key(gReceivedKeys, key_idx),
+                    llList2String(gReceivedHashes, key_idx)
+                );
+            }
+        } else if (channel == AV2_ANIMESH_CHANNEL) {
+            handleFurnitureMsg(id, msg);
+        }
+    }
+
+    changed(integer change) {
+        if (change & CHANGED_INVENTORY) {
+            gInventoryDirtied = llGetUnixTime();
+        }
+    }
+
+    timer() {
+        if (gConnState == CONN_STATE_DISCOVERY) {
+            if(llGetListLength(gReceivedNames)) {
+                llDialog(
+                    llGetOwner(),
+                    "Which furniture would you like to pair with?",
+                    gReceivedNames,
+                    DIALOG_CHANNEL
+                );
+                setConnState(CONN_STATE_CHOOSING);
+            } else {
+                llOwnerSay("Didn't detect any furniture nearby");
+                setConnState(CONN_STATE_DISCONNECTED);
+            }
+        } else if (gConnState == CONN_STATE_CHOOSING) {
+            llOwnerSay("Timed out while choosing a furniture to control");
+            setConnState(CONN_STATE_DISCONNECTED);
+        } else if (gConnState == CONN_STATE_WAITING) {
+            llOwnerSay("Timed out waiting for approval");
+            setConnState(CONN_STATE_DISCONNECTED);
+        } else if(gConnState == CONN_STATE_CONNECTED) {
+            if (llGetBoundingBox(gTargetFurniture) == []) {
+                llOwnerSay("Furniture went away!");
+                setConnState(CONN_STATE_DISCONNECTED);
+            }
+        }
+
+        if (gInventoryDirtied && gInventoryDirtied + 5 < llGetUnixTime()) {
+            gInventoryDirtied = FALSE;
+            recalcAnimsHash();
+        }
+    }
+}

--- a/AVsitter2/Plugins/AVdummy/[AV]dummy.lsl
+++ b/AVsitter2/Plugins/AVdummy/[AV]dummy.lsl
@@ -53,9 +53,9 @@ string truncateDialogButton(string text) {
 integer mayControlMenu(key id) {
     if (id == llGetOwner())
         return TRUE;
-    if (gFurnitureKey != NULL_KEY && SITTERS_MAY_CONTROL)
+    if (gTargetFurniture != NULL_KEY && SITTERS_MAY_CONTROL)
         // TODO: get SITTERS from anim broadcast and use that?
-        return llList2Key(llGetObjectDetails(id, [OBJECT_ROOT]), 0) == gFurnitureKey;
+        return llList2Key(llGetObjectDetails(id, [OBJECT_ROOT]), 0) == gTargetFurniture;
     return FALSE;
 }
 
@@ -258,7 +258,7 @@ default {
                 }
             } else if (gConnState == CONN_STATE_CONNECTED) {
                 if (mayControlMenu(id))
-                    sendCmd("SHOW_MENU|" + id);
+                    sendCmd("SHOW_MENU|" + (string)id);
             }
         }
     }

--- a/AVsitter2/Plugins/AVdummy/[AV]root-dummy.lsl
+++ b/AVsitter2/Plugins/AVdummy/[AV]root-dummy.lsl
@@ -113,7 +113,7 @@ default {
                 sendDirect(id, "DISCOVERY_PONG|" + llGetObjectName() + "|" + gAnimsHash);
             } else if (llList2String(msg_parsed, 0) == "CONNECT") {
                 pruneDeadDummies();
-                if (llGetListLength(gPensingSitters) > MAX_PENDING) {
+                if (llGetListLength(gPendingDummies) > MAX_PENDING) {
                     sendDirect(id, "CONNECT_RESP|no_seats");
                     return;
                 }

--- a/AVsitter2/Plugins/AVdummy/[AV]root-dummy.lsl
+++ b/AVsitter2/Plugins/AVdummy/[AV]root-dummy.lsl
@@ -1,0 +1,206 @@
+/*
+ * [AV]root-dummy - Handles communication with animesh dummies
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright © the AVsitter Contributors (http://avsitter.github.io)
+ * AVsitter™ is a trademark. For trademark use policy see:
+ * https://avsitter.github.io/TRADEMARK.mediawiki
+ *
+ * Please consider supporting continued development of AVsitter and
+ * receive automatic updates and other benefits! All details and user
+ * instructions can be found at http://avsitter.github.io
+ */
+
+// Only allow dummies owned by the furniture owner to "sit"
+integer OWNER_ONLY = TRUE;
+
+integer AV2_ANIMESH_CHANNEL = -1252168;
+integer PENDING_TTL = 5;
+integer MAX_PENDING = 10;
+
+string gAnimsHash;
+integer gAnimsTransferrable;
+integer gAnimsCopyable;
+integer gInventoryDirtied;
+
+list gSittingDummies;
+list gPendingDummies;
+list gPendingDummiesTimes;
+list gPendingDummiesNeedAnims;
+
+sendDummyAnims(key receiver) {
+    integer num = llGetInventoryNumber(INVENTORY_ANIMATION);
+    integer i;
+    for(i=0; i<num; ++i) {
+        llGiveInventory(receiver, llGetInventoryName(INVENTORY_ANIMATION, i));
+    }
+}
+
+recalcAnims() {
+    integer num = llGetInventoryNumber(INVENTORY_ANIMATION);
+    integer i;
+    gAnimsHash = "";
+    gAnimsTransferrable = TRUE;
+    gAnimsCopyable = TRUE;
+    for(i=0; i<num; ++i) {
+        string name = llGetInventoryName(INVENTORY_ANIMATION, i);
+        if (gAnimsTransferrable)
+            gAnimsTransferrable = (llGetInventoryPermMask(name, MASK_NEXT) & PERM_TRANSFER) == PERM_TRANSFER;
+        if (gAnimsCopyable)
+            gAnimsCopyable = (llGetInventoryPermMask(name, MASK_OWNER) & PERM_COPY) == PERM_COPY;
+        gAnimsHash = llSHA1String(name + gAnimsHash);
+    }
+}
+
+disconnectDummy(key id) {
+    integer sit_idx = llListFindList(gSittingDummies, [id]);
+    if (sit_idx == -1)
+        return;
+    sendDirect(id, "DISCONNECT");
+    gSittingDummies = llDeleteSubList(gSittingDummies, sit_idx, sit_idx);
+    llMessageLinked(LINK_SET, 90401, "", id); // 90400=non-avatar wants to disconnect
+}
+
+pruneDeadDummies() {
+    integer i;
+    integer len = llGetListLength(gSittingDummies);
+    for(i=len-1; i>0; --i) {
+        key id = llList2Key(gSittingDummies, i);
+        if (llGetBoundingBox(id) == []) {
+            disconnectDummy(id);
+        }
+    }
+}
+
+sendDirect(key id, string msg) {
+    llRegionSayTo(id, AV2_ANIMESH_CHANNEL, msg);
+}
+
+sendBroadcast(string msg) {
+    llRegionSay(AV2_ANIMESH_CHANNEL, msg);
+}
+
+default {
+    state_entry() {
+        llListen(AV2_ANIMESH_CHANNEL, "", "", "");
+        // Let any existing objects know we restarted so they're off in the void now
+        sendBroadcast("DISCONNECT");
+        // Let sitA scripts know that any non-avatar sitters are now dead if we restarted
+        llMessageLinked(LINK_SET, 90402, "", ""); // 90402=disconnect all non-avatar sitters
+        recalcAnims();
+        llSetTimerEvent(2.0);
+    }
+
+    listen(integer channel, string name, key id, string msg) {
+        if (OWNER_ONLY && llGetOwnerKey(id) != llGetOwner())
+            return;
+
+        list msg_parsed = llParseString2List(msg, ["|"], []);
+        integer sit_idx = llListFindList(gSittingDummies, [id]);
+        if (sit_idx != -1) {
+            if (llList2String(msg_parsed, 0) == "DISCONNECT") {
+                disconnectDummy(id);
+                return;
+            } else if (llList2String(msg_parsed, 0) == "SHOW_MENU") {
+                llMessageLinked(LINK_ROOT, 90004, "", llList2String(msg_parsed, 1) + "|" + (string)id); // 90004=show top menu
+            }
+        } else {
+            if (llList2String(msg_parsed, 0) == "DISCOVERY_PING") {
+                pruneDeadDummies();
+                sendDirect(id, "DISCOVERY_PONG|" + llGetObjectName() + "|" + gAnimsHash);
+            } else if (llList2String(msg_parsed, 0) == "CONNECT") {
+                pruneDeadDummies();
+                if (llGetListLength(gPensingSitters) > MAX_PENDING) {
+                    sendDirect(id, "CONNECT_RESP|no_seats");
+                    return;
+                }
+
+                integer need_anims = llList2Integer(msg_parsed, 2);
+                if (need_anims) {
+                    if (!gAnimsCopyable) {
+                        sendDirect(id, "CONNECT_RESP|no_copy_anims");
+                        return;
+                    }
+                    if (!gAnimsTransferrable && llGetOwnerKey(id) != llGetOwner()) {
+                        sendDirect(id, "CONNECT_RESP|no_transfer_anims");
+                        return;
+                    }
+                }
+                gPendingDummies += [id];
+                gPendingDummiesTimes += [llGetUnixTime()];
+                gPendingDummiesNeedAnims += [need_anims];
+                llMessageLinked(LINK_SET, 90400, llList2String(msg_parsed, 1), id); // 90400=non-avatar wants to sit
+            }
+        }
+    }
+
+    changed(integer change) {
+        if (change & CHANGED_INVENTORY) {
+            // Don't lock up the script if we get a ton of anims dropped in at once
+            gInventoryDirtied = llGetUnixTime();
+        }
+    }
+
+    link_message(integer sender_num, integer num, string msg, key id) {
+        integer one = (integer)msg;
+        integer two = (integer)((string)id);
+
+        if (num == 90299) { // 90299=send Reset to AVsitB
+            // If a sitA script reset then its SITTERS will now be out of sync with
+            // everyone else. Reset ourselves and disconnect any non-avatar sitters.
+            llResetScript();
+        }
+
+        integer sit_idx = llListFindList(gSittingDummies, [id]);
+        if (sit_idx == -1) {
+            if (num == 90060) { // 90060=welcome new sitter
+                integer pending_idx = llListFindList(gPendingDummies, [id]);
+                // a sitA script picked up a pending sitter!
+                if (pending_idx != -1) {
+                    gSittingDummies += [id];
+                    sendDirect(id, "CONNECT_RESP|");
+                    if (llList2Integer(gPendingDummiesNeedAnims, pending_idx)) {
+                        sendDummyAnims(id);
+                    }
+
+                    gPendingDummies = llDeleteSubList(gPendingDummies, pending_idx, pending_idx);
+                    gPendingDummiesTimes = llDeleteSubList(gPendingDummiesTimes, pending_idx, pending_idx);
+                    gPendingDummiesNeedAnims = llDeleteSubList(gPendingDummiesNeedAnims, pending_idx, pending_idx);
+                }
+            }
+        } else {
+            if (num == 90080) { // 90080=play animation
+                sendDirect(id, "START_ANIM|" + msg);
+            } else if (num == 90081) { // 90080=stop animation
+                sendDirect(id, "STOP_ANIM|" + msg);
+            } else if (num == 90085) { // 90085=reposition avatar
+                sendDirect(id, "REPOSITION|" + msg);
+            }
+        }
+    }
+
+    timer() {
+        pruneDeadDummies();
+
+        integer i;
+        integer len = llGetListLength(gPendingDummies);
+        for(i=len-1; i>0; --i) {
+            // Timed out, no sitA scripts were willing to take 'em
+            if(llList2Integer(gPendingDummiesTimes, i) + PENDING_TTL < llGetUnixTime()) {
+                key id = llList2Key(gPendingDummies, i);
+                gPendingDummies = llDeleteSubList(gPendingDummies, i, i);
+                gPendingDummiesTimes = llDeleteSubList(gPendingDummiesTimes, i, i);
+                gPendingDummiesNeedAnims = llDeleteSubList(gPendingDummiesNeedAnims, i, i);
+                sendDirect(id, "CONNECT_RESP|no_seats");
+            }
+        }
+
+        if (gInventoryDirtied && gInventoryDirtied + 5 < llGetUnixTime()) {
+            gInventoryDirtied = FALSE;
+            recalcAnims();
+        }
+    }
+}

--- a/AVsitter2/Plugins/AVdummy/comms_notes.md
+++ b/AVsitter2/Plugins/AVdummy/comms_notes.md
@@ -1,0 +1,81 @@
+# DUMMY COMMS PROTO
+
+All happens over a single well-known channel `-1252168`
+
+Intentionally no liveness ping / pong check, so bad sim lag or restarts won't cause a dummy to lose its association with furniture.
+
+### DISCOVERY_PING (dummy->furniture): Well-known channel (broadcast)
+
+Dummy scanning for furniture
+
+* no params
+
+### DISCOVERY_PONG (furniture->dummy): Well-known channel (direct)
+* string friendly_name (Probably llGetObjectName() or root object's name)
+* string anims_hash (hash of all anims in inventory created iteratively in
+  lexical order like `sha1(anim2 + sha1(anim1)))`. If there is a mismatch
+  dummy should remove all existing anims before attempting connect and pass
+  a `need_anims` of `TRUE` in its `CONNECT`)
+
+### SOLICIT (furniture->dummy): Well-known channel (direct)
+
+Furniture asking a dummy to sit down, usually if the
+furniture just rezzed the dummy itself. Dummy should follow up
+with a `CONNECT` if it wants to sit.
+
+* string anim_hash
+
+### CONNECT (dummy->furniture): Well-known channel (direct)
+
+Attempt to "sit" on the furniture.
+
+furniture should usually (but not necessarily) return an error if dummy and furniture don't have
+the same owner. furniture will normally beam over their anim contents via `llGiveInventory()`,
+but that isn't an option if there's an owner mismatch. That shouldn't be a problem if the
+owner of the dummy bootstraps its inv contents with whatever anims it might need (bearing in
+mind that there may be anim name collisions between different furniture.)
+
+* integer gender (necessary for gendered poses)
+* integer need_anims (furniture needs to send anims for us to be able to connect successfully)
+
+
+### CONNECT_RESP (furniture->dummy): Well-known channel (direct)
+
+Respond to `CONNECT`, failure if `error` is non-empty.
+
+* string error
+
+### DISCONNECT (dummy<->furniture): Well-known channel (direct or broadcast)
+
+Tell the other end that we're going away, broadcast via whisper on script
+restarts so the other end knows that we're no longer paying attention even
+though we no longer have a UUID to tell them directly.
+
+* no params
+
+### SHOW_MENU (dummy->furniture): Well-known channel (direct)
+
+Ask the furniture's sit script to allow someone to control dummy's menu.
+Furniture will not restrict access to this, so the dummy should do its own perms checks
+before sending this message.
+
+* key controller
+
+### START_ANIM (furniture->dummy): Well-known channel
+* string anim_name
+
+### STOP_ANIM (furniture->dummy): Well-known channel
+* string anim_name
+
+### REPOSITION (furniture->dummy): Well-known channel
+* vector pos (relative to furniture root)
+* rotation rot
+
+
+## COMMS TODO
+
+* Props? llGiveInventory() + llRezObject() + llCreateLink(), bookkeeping of links?
+* RLV pseudo-relay?
+* Proxy Xcite stuff?
+* More ability for dummies to control furniture programmatically?
+* Send anim info to dummies?

--- a/AVsitter2/Plugins/AVdummy/comms_notes.md
+++ b/AVsitter2/Plugins/AVdummy/comms_notes.md
@@ -4,20 +4,20 @@ All happens over a single well-known channel `-1252168`
 
 Intentionally no liveness ping / pong check, so bad sim lag or restarts won't cause a dummy to lose its association with furniture.
 
-### DISCOVERY_PING (dummy->furniture): Well-known channel (broadcast)
+### DISCOVERY_PING (dummy->furniture): broadcast
 
 Dummy scanning for furniture
 
 * no params
 
-### DISCOVERY_PONG (furniture->dummy): Well-known channel (direct)
+### DISCOVERY_PONG (furniture->dummy): direct
 * string friendly_name (Probably llGetObjectName() or root object's name)
 * string anims_hash (hash of all anims in inventory created iteratively in
   lexical order like `sha1(anim2 + sha1(anim1)))`. If there is a mismatch
   dummy should remove all existing anims before attempting connect and pass
   a `need_anims` of `TRUE` in its `CONNECT`)
 
-### SOLICIT (furniture->dummy): Well-known channel (direct)
+### SOLICIT (furniture->dummy): direct
 
 Furniture asking a dummy to sit down, usually if the
 furniture just rezzed the dummy itself. Dummy should follow up
@@ -25,7 +25,7 @@ with a `CONNECT` if it wants to sit.
 
 * string anim_hash
 
-### CONNECT (dummy->furniture): Well-known channel (direct)
+### CONNECT (dummy->furniture): direct
 
 Attempt to "sit" on the furniture.
 
@@ -39,13 +39,13 @@ mind that there may be anim name collisions between different furniture.)
 * integer need_anims (furniture needs to send anims for us to be able to connect successfully)
 
 
-### CONNECT_RESP (furniture->dummy): Well-known channel (direct)
+### CONNECT_RESP (furniture->dummy): direct
 
 Respond to `CONNECT`, failure if `error` is non-empty.
 
 * string error
 
-### DISCONNECT (dummy<->furniture): Well-known channel (direct or broadcast)
+### DISCONNECT (dummy<->furniture): direct or broadcast
 
 Tell the other end that we're going away, broadcast via whisper on script
 restarts so the other end knows that we're no longer paying attention even
@@ -53,7 +53,7 @@ though we no longer have a UUID to tell them directly.
 
 * no params
 
-### SHOW_MENU (dummy->furniture): Well-known channel (direct)
+### SHOW_MENU (dummy->furniture): direct
 
 Ask the furniture's sit script to allow someone to control dummy's menu.
 Furniture will not restrict access to this, so the dummy should do its own perms checks
@@ -61,13 +61,13 @@ before sending this message.
 
 * key controller
 
-### START_ANIM (furniture->dummy): Well-known channel
+### START_ANIM (furniture->dummy): direct
 * string anim_name
 
-### STOP_ANIM (furniture->dummy): Well-known channel
+### STOP_ANIM (furniture->dummy): direct
 * string anim_name
 
-### REPOSITION (furniture->dummy): Well-known channel
+### REPOSITION (furniture->dummy): direct
 * vector pos (relative to furniture root)
 * rotation rot
 

--- a/AVsitter2/[AV]sitA.lsl
+++ b/AVsitter2/[AV]sitA.lsl
@@ -914,7 +914,7 @@ default
         if (num == 90400) // 90400=non-avatar wants to sit
         {
             // TODO: Can't currently support non-avatar sitters in this configuration
-            if (SET == -1 && llGetListLength(SITTERS) > 1)
+            if (!(SET == -1 && llGetListLength(SITTERS) > 1))
                 return;
             handle_sit_attempt(id, one);
             return;

--- a/AVsitter2/[AV]sitB.lsl
+++ b/AVsitter2/[AV]sitB.lsl
@@ -353,6 +353,8 @@ default
 
     changed(integer change)
     {
+        // FIXME: broken if last sitter is animesh :/
+        /*
         if (change & CHANGED_LINK)
         {
             if (llGetAgentSize(llGetLinkKey(llGetNumberOfPrims())) == ZERO_VECTOR)
@@ -373,6 +375,7 @@ default
                 }
             }
         }
+        */
     }
 
     link_message(integer sender, integer num, string msg, key id)

--- a/AVsitter2/avsitter2_link_message_reference.md
+++ b/AVsitter2/avsitter2_link_message_reference.md
@@ -192,6 +192,21 @@ Used by oldschool HELPER 1 method - ask to animate.
 ### 90076
 Used by oldschool HELPER 1 method - stop animate.
 
+### 90080
+[AV]sitA started playing an animation
+
+    llMessageLinked(LINK_THIS,90070,<ANIMATION_NAME>,<AVATAR_UUID>);
+
+### 90081
+[AV]sitA stopped playing an animation
+
+    llMessageLinked(LINK_THIS,90070,<ANIMATION_NAME>,<AVATAR_UUID>);
+
+### 90085
+[AV]sitA moved an avatar around, rotation and position relative to the root's global position and rotation
+
+    llMessageLinked(LINK_THIS,90070,<POSITION,ROTATION>,<AVATAR_UUID>);
+
 ### 90100
 Menu choice from [AV]sitA. Also sent by [AV]sitB for [RLV] button and by [AV]root-RLV-extra for [BACK]
 
@@ -277,6 +292,21 @@ More [AV]sitA, [AV]adjuster updates to [AV]sitB.
 
 ### 90302
 [AV]sitA sends initial notecard settings data to [AV]sitB.
+
+### 90400
+Plugin tells [AV]sitA a non-avatar wants to "sit". Should be treated as if a new avatar was detected in the changed() event.
+
+    llMessageLinked(LINK_SET,90400,"",<OBJECT_UUID>);
+
+### 90401
+Plugin tells [AV]sitA a non-avatar disconnected. Should be treated as if an avatar stood up.
+
+    llMessageLinked(LINK_SET,90401,"",<OBJECT_UUID>);
+
+### 90402
+Plugin tells [AV]sitA to release all non-avatar sitters.
+
+    llMessageLinked(LINK_SET,90402,"","");
 
 ### 90500
 [AV]prop reports on prop events (ATTACHED,DETACHED,REZ,DEREZ).

--- a/AVsitter2/avsitter2_link_message_reference.md
+++ b/AVsitter2/avsitter2_link_message_reference.md
@@ -195,17 +195,17 @@ Used by oldschool HELPER 1 method - stop animate.
 ### 90080
 [AV]sitA started playing an animation
 
-    llMessageLinked(LINK_THIS,90070,<ANIMATION_NAME>,<AVATAR_UUID>);
+    llMessageLinked(LINK_SET,90080,<ANIMATION_NAME>,<AVATAR_UUID>);
 
 ### 90081
 [AV]sitA stopped playing an animation
 
-    llMessageLinked(LINK_THIS,90070,<ANIMATION_NAME>,<AVATAR_UUID>);
+    llMessageLinked(LINK_SET,90081,<ANIMATION_NAME>,<AVATAR_UUID>);
 
 ### 90085
 [AV]sitA moved an avatar around, rotation and position relative to the root's global position and rotation
 
-    llMessageLinked(LINK_THIS,90070,<POSITION,ROTATION>,<AVATAR_UUID>);
+    llMessageLinked(LINK_SET,90085,<POSITION,ROTATION>,<AVATAR_UUID>);
 
 ### 90100
 Menu choice from [AV]sitA. Also sent by [AV]sitB for [RLV] button and by [AV]root-RLV-extra for [BACK]


### PR DESCRIPTION
This PR adds a plugin to support animesh dummies on AVsitter2 furniture, along with a reference dummy implementation. Not married to the design or message numbers, but seems to work well enough for my own use and allows drop-in support for animesh dummies in existing furniture. Happy to make any changes or split this out differently.

# Typical pairing flow with reference dummy
* user rezzes dummy
* user clicks dummy to have it enter furniture discovery mode
* dummy broadcasts discovery ping on standard channel
* furniture within listening range sends discovery pong
* * discovery pong includes a hash of all anim names in its inventory so the dummy knows whether it already has the appropriate anims
* dummy gives a dialog of furniture and asks owner to choose one, filtering out furniture that does not have the same owner
* * Again, not strictly necessary, but owner inequality means people have to manually load in anims or do `llAllowInventoryDrop(TRUE)`.
* owner chooses which furniture to pair with
* dummy removes all old animations from its inventory if there was a mismatch of anims hash with furniture
* * not strictly necessary, but reduces the amount of bookkeeping we have to do to prevent anim name collisions
* dummy sends pairing message (should have gender of dummy for gendered furnitures)
* if furniture has a free slot it sends back message saying it accepts, otherwise rejection message
* dummy and furniture keep a reference to each other's UUIDs so they can speak directly & do basic liveness checks with `llGetBoundingBox()`.
* furniture sends any animations to the dummy via `llGiveInventory()` (if necessary.)
* furniture sends positioning and animation commands to dummy.

# Animation flow changes
* `llStart/StopAnimation()` are replaced with wrapper functions that skip the actual `llStart/StopAnimation()` call if sitter is not an av.
  animation names will additionally be sent via link messages to the root dummy plugin so it can proxy those messages to the dummy.
* Same thing with attempts to move the avatar around the linkset

# sitA changes
* Lots of calls to `llGetAgentSize(MY_SITTER)` & `llGetPermissions()` replaced.
* Removed a lot of assumptions that the sitter is part of the linkset
* Most of the code for handling new sitters was in the `CHANGED_LINK` handler, moved that out to a function.
* Same with `run_time_permissions`, whatever code in there now runs basically right after code pulled out of `CHANGED_LINK` in animesh case.

# Positioning of reference dummy
* Clicking dummy should bring up positioning menu if you're one of the other sitters
* AVSitter already has a notion of "controllers", proxy through request to show a menu for person that clicked dummy.

# TODOs
* Currently dummies are not supported if `!(SET == -1 && llGetListLength(SITTERS) > 1))`. If that needs to work then some finagling may be necessary since that seems to rely on assigning a specific sittarget to each sitter.
* A handful of lines like `if (llGetAgentSize(llGetLinkKey(llGetNumberOfPrims())) == ZERO_VECTOR)` are still present that would be problematic, plugins need to be smarter about checking that `SITTERS` is actually empty.
* Style changes?
* Extra messages that should be proxied to dummies?