### PR TITLE
Check permissions before starting/stopping overlay animations

### DIFF
--- a/AVsitter2/[AV]sitA.lsl
+++ b/AVsitter2/[AV]sitA.lsl
@@ -750,15 +750,14 @@ default
         }
         if (id == MY_SITTER)
         {
-            if (num == 90001) // 90001=start an overlay animation
+            if ((num == 90001 || num == 90002) // 90001=start an overlay animation
+                                               // 90002=stop an overlay animation
+                && (PERMISSION_TRIGGER_ANIMATION & llGetPermissions()) != 0)
             {
-                llStartAnimation(msg);
-                return;
-            }
-            if (num == 90002) // 90002=stop an overlay animation
-            {
-                llStopAnimation(msg);
-                return;
+                if (num == 90001)
+                    llStartAnimation(msg);
+                else
+                    llStopAnimation(msg);
             }
             data = llParseStringKeepNulls(msg, ["|"], data);
             if (num == 90101) // 90101=menu option chosen


### PR DESCRIPTION
This solves a race condition when avatars revoke animation permissions on stand, but the message needs to travel through several scripts and, in case of extreme lag conditions, can attempt to stop animations after the revocation arrives, resulting in an error.

Fixes #119. Big thanks to @ohhmye for reporting and investigating this bug.
