### PR TITLE
Rename [AV]helper to [AV]helperscript

### DIFF
--- a/AVsitter2/IMPORT_GUIDE.md
+++ b/AVsitter2/IMPORT_GUIDE.md
@@ -6,7 +6,7 @@ If you would prefer a packaged version of the latest release, and to receive pac
 
 ## Importing the AVsitter2 scripts into Second Life / OpenSim
 
-Quick summary: Download the scripts from the [releases page](https://github.com/AVsitter/AVsitter/releases); name them in the viewer the same as in the zip file but without extension, saving all of them with Mono enabled; create an [AV]helper *object*,and put the [AV]helper *script* inside and take it; create an AVpos notecard, add something to it and save it.
+Quick summary: Download the scripts from the [releases page](https://github.com/AVsitter/AVsitter/releases); name them in the viewer the same as in the zip file but without extension, saving all of them with Mono enabled; create an [AV]helper *object*, put the [AV]helperscript *script* inside and take it; create an AVpos notecard, add something to it and save it.
 
 Step-by-step guide:
 
@@ -46,7 +46,7 @@ Step-by-step guide:
 7. Prepare an **[AV]helper** object.
 
     - In Second Life or OpenSim, rez a box and name it **[AV]helper**.
-    - Inside its contents, drop the **[AV]helper** script that, at this point, you must have created by following the above procedure.
+    - Inside its contents, drop the **[AV]helperscript** script that, at this point, you must have created by following the above procedure.
     - Take the **[AV]helper** object to your inventory.
 
 8. There's still one thing to do to have the distribution working:
@@ -56,4 +56,4 @@ Step-by-step guide:
     - *Save* it. This step is very important. Notecards that have never been saved after being created will cause problems.
     - Use that notecard as an empty notecard when following the user instructions below.
 
-After importing the AVsitter2 scripts into Second Life or OpenSim, you are ready to follow the [AVsitter2 User Instructions](https://avsitter.github.io/avsitter2_home). Where the instructions mention the **[AV]helper** object, it refers to the object we've just created with the script inside.
+After importing the AVsitter2 scripts into Second Life or OpenSim, you are ready to follow the [AVsitter2 User Instructions](https://avsitter.github.io/avsitter2_home). Where the instructions mention the **[AV]helper** object, it refers to the object we've just created with the **[AV]helperscript** script inside.

--- a/AVsitter2/Makefile
+++ b/AVsitter2/Makefile
@@ -34,7 +34,7 @@ OSZIP=AVsitter2-oss.zip
 OPTIMIZED=[AV]sitA.lslo\
  [AV]sitB.lslo\
  [AV]adjuster.lslo\
- [AV]helper.lslo\
+ [AV]helperscript.lslo\
  [AV]root-security.lslo\
  [AV]root.lslo\
  [AV]select.lslo\
@@ -61,7 +61,7 @@ UNOPTIMIZED=Plugins/AVcontrol/LockGuard/[AV]LockGuard.lsl\
 OPENSIM=[AV]sitA.oss\
  [AV]sitB.oss\
  [AV]adjuster.oss\
- [AV]helper.oss\
+ [AV]helperscript.oss\
  [AV]root.oss\
  [AV]root-security.oss\
  [AV]select.oss\

--- a/AVsitter2/[AV]helperscript.lsl
+++ b/AVsitter2/[AV]helperscript.lsl
@@ -1,5 +1,5 @@
 /*
- * [AV]helper - Setup aid, to move poses by moving an object
+ * [AV]helperscript - Setup aid, to move poses by moving an object
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this


### PR DESCRIPTION
There has been a lot of confusion between the [AV]helper *object* and the [AV]helper *script*. To alleviate this problem, rename the script to a name with a distinct length and with the word 'script' in it.
