### PR TITLE
Reset the menu page when message 90004 is received

### DIFF
--- a/AVsitter2/[AV]sitB.lsl
+++ b/AVsitter2/[AV]sitB.lsl
@@ -442,6 +442,7 @@ default
                 if (num == 90004)
                 {
                     current_menu = -1;
+                    menu_page = 0;
                 }
                 else if (index != -1)
                 {


### PR DESCRIPTION
Fixes an issue reported by Arsone.Danick; it happens e.g. when the menu was left in a page other than the first, and another avatar takes control.