### PR TITLE
Add message 90008 to play poses as if they were selected by menu

### DIFF
--- a/AVsitter2/Plugins/AVsequence/[AV]sequence.lsl
+++ b/AVsitter2/Plugins/AVsequence/[AV]sequence.lsl
@@ -331,7 +331,7 @@ state running
             {
                 SITTERS = llListReplaceList(SITTERS, [id], (integer)msg, (integer)msg);
             }
-            else if (num == 90000)
+            else if (num == 90000 || num == 90008)
             {
                 stop_sequence(TRUE);
                 integer index = llListFindList(SEQUENCE_DATA_NAMES, [msg]);

--- a/AVsitter2/[AV]sitB.lsl
+++ b/AVsitter2/[AV]sitB.lsl
@@ -381,12 +381,15 @@ default
         integer two = (integer)((string)id);
         integer index;
         list data;
-        if (num == 90000 || num == 90010 || num == 90003)
+        if (num == 90000 || num == 90010 || num == 90003 || num == 90008)
         {
             index = llListFindList(MENU_LIST, [msg]);
             if (index == -1)
             {
                 index = llListFindList(MENU_LIST, ["P:" + msg]);
+                // If it's a POSE entry, don't treat it specially
+                if (~index && num == 90008)
+                    num = 90000;
             }
             if (id) // OSS::if (osIsUUID(id) && id != NULL_KEY)
             {
@@ -397,7 +400,7 @@ default
                 // assumed numeric - replace it with a "*" so we can test for it
                 id = "*";
             }
-            if ((id == "" || id == MY_SITTER || (id == "*" && two == SCRIPT_CHANNEL)) && (index != -1 || msg == ""))
+            if ((id == "" || id == MY_SITTER || (id == "*" && two == SCRIPT_CHANNEL) || num == 90008) && (index != -1 || msg == ""))
             {
                 ANIM_INDEX = index;
                 integer broadcast = TRUE;

--- a/AVsitter2/avsitter2_link_message_reference.md
+++ b/AVsitter2/avsitter2_link_message_reference.md
@@ -32,7 +32,7 @@ Stop an additional animation ([AV]adjuster, [AV]faces).
 Same as 90000 but ignored by [AV]sequence script to prevent from stopping sequences when [AV]sequence itself plays poses.
 
 ### 90004
-Same as 90005 but returns to top level of the menu (used by [AV]root-RLV when press [MENU]).
+Same as 90005 but returns to top level of the menu (used by [AV]root-RLV when pressing [MENU]).
 
 ### 90005
 Give the menu. Optionally set controller avatar and/or submenu.
@@ -54,6 +54,9 @@ Register touch or sit to [AV]root-security script from [AV]sitA after permission
 [AV]root-security passes touch to [AV]root-control.
 
     llMessageLinked(LINK_SET,90007,"",<CONTROLLER_UUID>);
+
+### 90008
+Same as 90000 but if the pose is a SYNC pose, it's played by all sitters that have it, regardless of target (i.e. works pretty much like choosing the pose in the menu)
 
 ### 90009
 Bring up [AV]select menu, sent by [AV]sitB.


### PR DESCRIPTION
The idea is to let plugins play POSEs or SYNCs without having to track whether it's a regular or a sync pose, just as if the user selected it from the menu. With 90000, in order to play a SYNC you have to send it to all, and in order to play a POSE without interfering with others, you have to send it to the desired specific sitter only.

@codeviolet I'd appreciate if you review it in case I'm missing some special case.