### PR TITLE
Added an extra linked message filter which passes the AV-Sitter menu …

### DIFF
--- a/AVsitter2/[AV]sitA.lsl
+++ b/AVsitter2/[AV]sitA.lsl
@@ -721,6 +721,11 @@ default
             llPassTouches(has_security);
             return;
         }
+        if (num == 2000)
+        {
+            //AV-Sitter menu requested externally, send the user the menu
+            llMessageLinked(LINK_THIS, 90005, "", id); // 90005=send menu to user
+        }
         if (num == 90203) // 90203=texture script present in root (unused)
         {
             has_texture = TRUE;


### PR DESCRIPTION
Added an extra linked message to allow another menu to have an "animate" button or similar, then have av-sitter send the user the Av-Sitter menu.

This returns the "PrimTouch" which was used in the original av-sitter. 

Useful when av-sitter is in a child prim and another menu controls other items. 