### PR TITLE
Add version code to most scripts

### DIFF
--- a/AVsitter2/Makefile
+++ b/AVsitter2/Makefile
@@ -28,6 +28,9 @@ OSZIP=AVsitter2-oss.zip
 # End of configuration area
 
 
+# Version being compiled (LSL string)
+VERSION="2.2"
+
 
 # Note some of these scripts don't strictly need to be optimized for memory.
 
@@ -101,4 +104,10 @@ $(OSZIP): $(OPENSIM)
 %.oss: %.lsl
 	$(PYTHON) build-aux.py oss-process $< > $@
 
-.PHONY : all clean optimized opensim
+# Bash only, probably GNU make only
+setvars:
+	for name in $(addprefix ',$(addsuffix ',$(OPTIMIZED:.lslo=.lsl))) $(addprefix ',$(addsuffix ',$(UNOPTIMIZED))); do $(PYTHON) build-aux.py setvars "$$name" version='$(VERSION)' ; done
+
+release: setvars all
+
+.PHONY : all clean optimized opensim setvars release

--- a/AVsitter2/Makefile
+++ b/AVsitter2/Makefile
@@ -29,7 +29,7 @@ OSZIP=AVsitter2-oss.zip
 
 
 # Version being compiled (LSL string)
-VERSION="2.2"
+VERSION="2.2p04"
 
 
 # Note some of these scripts don't strictly need to be optimized for memory.

--- a/AVsitter2/Plugins/AVcamera/[AV]camera.lsl
+++ b/AVsitter2/Plugins/AVcamera/[AV]camera.lsl
@@ -14,7 +14,7 @@
  * instructions can be found at http://avsitter.github.io
  */
 
-string #version = "2.2";
+string #version = "2.2p04";
 string notecard_name = "AVpos";
 string main_script = "[AV]sitA";
 key notecard_key;

--- a/AVsitter2/Plugins/AVcamera/[AV]camera.lsl
+++ b/AVsitter2/Plugins/AVcamera/[AV]camera.lsl
@@ -14,7 +14,7 @@
  * instructions can be found at http://avsitter.github.io
  */
 
-string version = "2.2";
+string #version = "2.2";
 string notecard_name = "AVpos";
 string main_script = "[AV]sitA";
 key notecard_key;

--- a/AVsitter2/Plugins/AVcontrol/LockGuard/[AV]LockGuard-object.lsl
+++ b/AVsitter2/Plugins/AVcontrol/LockGuard/[AV]LockGuard-object.lsl
@@ -16,7 +16,7 @@
 
 // Placed in prop objects, this script sends the uuid of any Lockguard rings to the script in furniture.
 // Ring prims in the prop should be named with "ring" in their prim name. e.g. "ring1", "ring2"
-
+// string #version = "2.2";
 integer COMM_CHANNEL = -57841689;
 integer comm_handle;
 list A = [comm_handle]; //OSS::list A; // Force error if not compiled in Mono

--- a/AVsitter2/Plugins/AVcontrol/LockGuard/[AV]LockGuard-object.lsl
+++ b/AVsitter2/Plugins/AVcontrol/LockGuard/[AV]LockGuard-object.lsl
@@ -16,7 +16,7 @@
 
 // Placed in prop objects, this script sends the uuid of any Lockguard rings to the script in furniture.
 // Ring prims in the prop should be named with "ring" in their prim name. e.g. "ring1", "ring2"
-// string #version = "2.2";
+// string #version = "2.2p04";
 integer COMM_CHANNEL = -57841689;
 integer comm_handle;
 list A = [comm_handle]; //OSS::list A; // Force error if not compiled in Mono

--- a/AVsitter2/Plugins/AVcontrol/LockGuard/[AV]LockGuard.lsl
+++ b/AVsitter2/Plugins/AVcontrol/LockGuard/[AV]LockGuard.lsl
@@ -13,10 +13,10 @@
  * receive automatic updates and other benefits! All details and user
  * instructions can be found at http://avsitter.github.io
  */
-
 //  For use attaching particle chains to LockGuard V2 compatible cuffs such as Open Collar
 //  This script should be placed inside the prim that contains your poses and props.
 //  Inspiration and function (not code) from the Bright CISS system by Shan Bright & Innula Zenovka.
+// string #version = "2.2";
 
 //  SITTER:
 //      The AVsitter SITTER # the chain settings are for.

--- a/AVsitter2/Plugins/AVcontrol/LockGuard/[AV]LockGuard.lsl
+++ b/AVsitter2/Plugins/AVcontrol/LockGuard/[AV]LockGuard.lsl
@@ -16,7 +16,7 @@
 //  For use attaching particle chains to LockGuard V2 compatible cuffs such as Open Collar
 //  This script should be placed inside the prim that contains your poses and props.
 //  Inspiration and function (not code) from the Bright CISS system by Shan Bright & Innula Zenovka.
-// string #version = "2.2";
+// string #version = "2.2p04";
 
 //  SITTER:
 //      The AVsitter SITTER # the chain settings are for.

--- a/AVsitter2/Plugins/AVcontrol/[AV]root-RLV-extra.lsl
+++ b/AVsitter2/Plugins/AVcontrol/[AV]root-RLV-extra.lsl
@@ -15,7 +15,7 @@
  */
 
 string product;
-string #version = "2.2";
+string #version = "2.2p04";
 integer RELAY_CHANNEL = -1812221819;
 integer RELAY_GETSTATUS_CHANNEL;
 integer GETSTATUShandle;

--- a/AVsitter2/Plugins/AVcontrol/[AV]root-RLV-extra.lsl
+++ b/AVsitter2/Plugins/AVcontrol/[AV]root-RLV-extra.lsl
@@ -15,7 +15,7 @@
  */
 
 string product;
-string version = "2.2";
+string #version = "2.2";
 integer RELAY_CHANNEL = -1812221819;
 integer RELAY_GETSTATUS_CHANNEL;
 integer GETSTATUShandle;

--- a/AVsitter2/Plugins/AVcontrol/[AV]root-RLV.lsl
+++ b/AVsitter2/Plugins/AVcontrol/[AV]root-RLV.lsl
@@ -15,7 +15,7 @@
  */
 
 string product = "AVsitter™ RLV";
-string version = "2.2";
+string #version = "2.2";
 integer ignorenextswap;
 string notecard_name = "AVpos";
 string unDressScript = "[AV]root-RLV-extra";

--- a/AVsitter2/Plugins/AVcontrol/[AV]root-RLV.lsl
+++ b/AVsitter2/Plugins/AVcontrol/[AV]root-RLV.lsl
@@ -15,7 +15,7 @@
  */
 
 string product = "AVsitter™ RLV";
-string #version = "2.2";
+string #version = "2.2p04";
 integer ignorenextswap;
 string notecard_name = "AVpos";
 string unDressScript = "[AV]root-RLV-extra";

--- a/AVsitter2/Plugins/AVcontrol/[AV]root-control.lsl
+++ b/AVsitter2/Plugins/AVcontrol/[AV]root-control.lsl
@@ -15,7 +15,7 @@
  */
 
 string product = "AVsitter™ Menu Control";
-string version = "2.2";
+string #version = "2.2";
 string security_script = "[AV]root-security";
 string RLV_script = "[AV]root-RLV";
 list DESIGNATIONS_NOW;

--- a/AVsitter2/Plugins/AVcontrol/[AV]root-control.lsl
+++ b/AVsitter2/Plugins/AVcontrol/[AV]root-control.lsl
@@ -15,7 +15,7 @@
  */
 
 string product = "AVsitter™ Menu Control";
-string #version = "2.2";
+string #version = "2.2p04";
 string security_script = "[AV]root-security";
 string RLV_script = "[AV]root-RLV";
 list DESIGNATIONS_NOW;

--- a/AVsitter2/Plugins/AVfaces/[AV]faces.lsl
+++ b/AVsitter2/Plugins/AVfaces/[AV]faces.lsl
@@ -43,7 +43,7 @@ integer IsInteger(string data)
     return data != "" && (string)((integer)("1" + data)) == "1" + data;
 }
 
-string #version = "2.2";
+string #version = "2.2p04";
 string notecard_name = "AVpos";
 string main_script = "[AV]sitA";
 key key_request;

--- a/AVsitter2/Plugins/AVfaces/[AV]faces.lsl
+++ b/AVsitter2/Plugins/AVfaces/[AV]faces.lsl
@@ -43,7 +43,7 @@ integer IsInteger(string data)
     return data != "" && (string)((integer)("1" + data)) == "1" + data;
 }
 
-string version = "2.2";
+string #version = "2.2";
 string notecard_name = "AVpos";
 string main_script = "[AV]sitA";
 key key_request;

--- a/AVsitter2/Plugins/AVprop/[AV]menu.lsl
+++ b/AVsitter2/Plugins/AVprop/[AV]menu.lsl
@@ -15,7 +15,7 @@
  */
 
 string product = "AVmenu™";
-string version = "2.2";
+string #version = "2.2";
 integer verbose = 0;
 string prop_script = "[AV]prop";
 string notecard_name = "AVpos";

--- a/AVsitter2/Plugins/AVprop/[AV]menu.lsl
+++ b/AVsitter2/Plugins/AVprop/[AV]menu.lsl
@@ -15,7 +15,7 @@
  */
 
 string product = "AVmenu™";
-string #version = "2.2";
+string #version = "2.2p04";
 integer verbose = 0;
 string prop_script = "[AV]prop";
 string notecard_name = "AVpos";

--- a/AVsitter2/Plugins/AVprop/[AV]prop.lsl
+++ b/AVsitter2/Plugins/AVprop/[AV]prop.lsl
@@ -14,7 +14,7 @@
  * instructions can be found at http://avsitter.github.io
  */
 
-string #version = "2.2";
+string #version = "2.2p04";
 string notecard_name = "AVpos";
 string main_script = "[AV]sitA";
 key key_request;

--- a/AVsitter2/Plugins/AVprop/[AV]prop.lsl
+++ b/AVsitter2/Plugins/AVprop/[AV]prop.lsl
@@ -14,7 +14,7 @@
  * instructions can be found at http://avsitter.github.io
  */
 
-string version = "2.2";
+string #version = "2.2";
 string notecard_name = "AVpos";
 string main_script = "[AV]sitA";
 key key_request;

--- a/AVsitter2/Plugins/AVsequence/[AV]sequence.lsl
+++ b/AVsitter2/Plugins/AVsequence/[AV]sequence.lsl
@@ -15,7 +15,7 @@
  */
 
 string product = "AVsitter™ sequence";
-string version = "2.2";
+string #version = "2.2";
 string main_script = "[AV]sitA";
 list SITTERS;
 integer DEBUG;

--- a/AVsitter2/Plugins/AVsequence/[AV]sequence.lsl
+++ b/AVsitter2/Plugins/AVsequence/[AV]sequence.lsl
@@ -15,7 +15,7 @@
  */
 
 string product = "AVsitter™ sequence";
-string #version = "2.2";
+string #version = "2.2p04";
 string main_script = "[AV]sitA";
 list SITTERS;
 integer DEBUG;

--- a/AVsitter2/Utilities/MLP-converter.lsl
+++ b/AVsitter2/Utilities/MLP-converter.lsl
@@ -15,7 +15,7 @@
  */
 
 string product = "AVsitter2 MLP converter";
-string #version = "2.2";
+string #version = "2.2p04";
 string notecard_basename = "AVpos";
 string notecard_name;
 list NOTECARDS = [notecard_name]; //OSS::list NOTECARDS; // Force error in LSO

--- a/AVsitter2/Utilities/MLP-converter.lsl
+++ b/AVsitter2/Utilities/MLP-converter.lsl
@@ -15,7 +15,7 @@
  */
 
 string product = "AVsitter2 MLP converter";
-string version = "2.2";
+string #version = "2.2";
 string notecard_basename = "AVpos";
 string notecard_name;
 list NOTECARDS = [notecard_name]; //OSS::list NOTECARDS; // Force error in LSO

--- a/AVsitter2/[AV]adjuster.lsl
+++ b/AVsitter2/[AV]adjuster.lsl
@@ -17,7 +17,7 @@
 integer OLD_HELPER_METHOD;
 key key_request;
 string url = "https://avsitter.com/settings.php"; // the settings dump service remains up for AVsitter customers. settings clear periodically.
-string #version = "2.2";
+string #version = "2.2p04";
 string helper_name = "[AV]helper";
 string prop_script = "[AV]prop";
 string expression_script = "[AV]faces";

--- a/AVsitter2/[AV]adjuster.lsl
+++ b/AVsitter2/[AV]adjuster.lsl
@@ -17,7 +17,7 @@
 integer OLD_HELPER_METHOD;
 key key_request;
 string url = "https://avsitter.com/settings.php"; // the settings dump service remains up for AVsitter customers. settings clear periodically.
-string version = "2.2";
+string #version = "2.2";
 string helper_name = "[AV]helper";
 string prop_script = "[AV]prop";
 string expression_script = "[AV]faces";

--- a/AVsitter2/[AV]helperscript.lsl
+++ b/AVsitter2/[AV]helperscript.lsl
@@ -16,7 +16,7 @@
 
 string registration_product = "AVsitter2";
 string product = "AVhelper";
-string #version = "2.2";
+string #version = "2.2p04";
 integer OLD_HELPER_METHOD;
 list colors = [<1,0.5,1>, <0.5,0.5,1>, <1,0.5,0.5>, <0.5,1,0.5>, <1,1,0.5>, <0.5,1,1>];
 integer helper_index;

--- a/AVsitter2/[AV]helperscript.lsl
+++ b/AVsitter2/[AV]helperscript.lsl
@@ -16,7 +16,7 @@
 
 string registration_product = "AVsitter2";
 string product = "AVhelper";
-string version = "2.2";
+string #version = "2.2";
 integer OLD_HELPER_METHOD;
 list colors = [<1,0.5,1>, <0.5,0.5,1>, <1,0.5,0.5>, <0.5,1,0.5>, <1,1,0.5>, <0.5,1,1>];
 integer helper_index;

--- a/AVsitter2/[AV]root-security.lsl
+++ b/AVsitter2/[AV]root-security.lsl
@@ -15,7 +15,7 @@
  */
 
 string product = "AVsitter™ Security";
-string #version = "2.2";
+string #version = "2.2p04";
 string script_basename = "[AV]sitA";
 string menucontrol_script = "[AV]root-control";
 string RLV_script = "[AV]root-RLV";

--- a/AVsitter2/[AV]root-security.lsl
+++ b/AVsitter2/[AV]root-security.lsl
@@ -14,7 +14,8 @@
  * instructions can be found at http://avsitter.github.io
  */
 
-string product = "AVsitter™ Security 2.2";
+string product = "AVsitter™ Security";
+string #version = "2.2";
 string script_basename = "[AV]sitA";
 string menucontrol_script = "[AV]root-control";
 string RLV_script = "[AV]root-RLV";
@@ -60,7 +61,7 @@ check_sitters()
         if (pass_security(av, "SIT") == FALSE)
         {
             llUnSit(av);
-            llDialog(av, product + "\n\nSorry, Sit access is set to: " + llList2String(SIT_TYPES, SIT_INDEX), ["OK"], -164289491);
+            llDialog(av, product + " " + version + "\n\nSorry, Sit access is set to: " + llList2String(SIT_TYPES, SIT_INDEX), ["OK"], -164289491);
         }
         i--;
     }
@@ -98,7 +99,7 @@ register_touch(key id, integer animation_menu_function, integer active_prim, int
     }
     else if (giveFailedMessage)
     {
-        llDialog(id, product + "\n\nSorry, Menu access is set to: " + llList2String(MENU_TYPES, MENU_INDEX), ["OK"], -164289491);
+        llDialog(id, product + " " + version + "\n\nSorry, Menu access is set to: " + llList2String(MENU_TYPES, MENU_INDEX), ["OK"], -164289491);
     }
 }
 
@@ -117,7 +118,7 @@ dialog(string text, list menu_items)
 {
     llListenRemove(menu_handle);
     menu_handle = llListen((menu_channel = ((integer)llFrand(0x7FFFFF80) + 1) * -1), "", llGetOwner(), ""); // 7FFFFF80 = max float < 2^31
-    llDialog(llGetOwner(), product + "\n\n" + text, order_buttons(menu_items), menu_channel);
+    llDialog(llGetOwner(), product + " " + version + "\n\n" + text, order_buttons(menu_items), menu_channel);
     llSetTimerEvent(600);
 }
 

--- a/AVsitter2/[AV]root.lsl
+++ b/AVsitter2/[AV]root.lsl
@@ -13,7 +13,7 @@
  * receive automatic updates and other benefits! All details and user
  * instructions can be found at http://avsitter.github.io
  */
-
+//string #version = "2.2";
 string script_basename = "[AV]sitA";
 string menu_script = "[AV]menu";
 key A;

--- a/AVsitter2/[AV]root.lsl
+++ b/AVsitter2/[AV]root.lsl
@@ -13,7 +13,7 @@
  * receive automatic updates and other benefits! All details and user
  * instructions can be found at http://avsitter.github.io
  */
-//string #version = "2.2";
+//string #version = "2.2p04";
 string script_basename = "[AV]sitA";
 string menu_script = "[AV]menu";
 key A;

--- a/AVsitter2/[AV]select.lsl
+++ b/AVsitter2/[AV]select.lsl
@@ -15,7 +15,7 @@
  */
 
 string product = "AVsitter™ seat select";
-string #version = "2.2";
+string #version = "2.2p04";
 integer select_type;
 list BUTTONS;
 integer reading_notecard_section = -1;

--- a/AVsitter2/[AV]select.lsl
+++ b/AVsitter2/[AV]select.lsl
@@ -15,7 +15,7 @@
  */
 
 string product = "AVsitter™ seat select";
-string version = "2.2";
+string #version = "2.2";
 integer select_type;
 list BUTTONS;
 integer reading_notecard_section = -1;

--- a/AVsitter2/[AV]sitA.lsl
+++ b/AVsitter2/[AV]sitA.lsl
@@ -15,7 +15,7 @@
  */
 
 string product = "AVsitter™";
-string version = "2.2";
+string #version = "2.2";
 string notecard_name = "AVpos";
 string main_script = "[AV]sitA";
 string memoryscript = "[AV]sitB";

--- a/AVsitter2/[AV]sitA.lsl
+++ b/AVsitter2/[AV]sitA.lsl
@@ -15,7 +15,7 @@
  */
 
 string product = "AVsitter™";
-string #version = "2.2";
+string #version = "2.2p04";
 string notecard_name = "AVpos";
 string main_script = "[AV]sitA";
 string memoryscript = "[AV]sitB";

--- a/AVsitter2/[AV]sitB.lsl
+++ b/AVsitter2/[AV]sitB.lsl
@@ -15,7 +15,7 @@
  */
 
 string product = "AVsitter™";
-string #version = "2.2";
+string #version = "2.2p04";
 string BRAND;
 integer OLD_HELPER_METHOD;
 string main_script = "[AV]sitA";

--- a/AVsitter2/[AV]sitB.lsl
+++ b/AVsitter2/[AV]sitB.lsl
@@ -15,7 +15,7 @@
  */
 
 string product = "AVsitter™";
-string version = "2.2";
+string #version = "2.2";
 string BRAND;
 integer OLD_HELPER_METHOD;
 string main_script = "[AV]sitA";

--- a/AVsitter2/build-aux.py
+++ b/AVsitter2/build-aux.py
@@ -13,6 +13,9 @@ python build-aux.py <command> [<args>]
 
 Where command can be:
 
+    setvars <file> <var>=<value> ...:
+        Preprocesses the given file in place, to replace values like
+        version and others.
     oss-process <file>:
         Processes the given file for OpenSim and outputs the result to
         standard output. If <file> is not given, read from standard input.
@@ -44,8 +47,12 @@ def oss_process(filename):
     # Regex that removes /*OSS:: and its matching */ (can't begin on first line)
     os_block_re = re.compile(r'\n\s*/\* ?OSS::[^\n]*(\n(?:[^\n]|\n(?![ \t]*\*/))*)\n[ \t]*\*/[^\n]*(?=\n)')
 
+    # Regex that reads a token, can be a string or comment or #IDENT or anything else,
+    # capturing a group for IDENT when #IDENT is found.
+    token_re = re.compile(r'"(?:\\.|[^"\\]+)*"|/\*[\S\s]*?\*/|//[^\n]*|/|[^#/"]+|#([a-zA-Z_][a-zA-Z0-9_]*)|#')
+
     if filename is not None:
-        f = open(filename, "r");
+        f = open(filename, "r")
     else:
         f = sys.stdin
     try:
@@ -59,7 +66,6 @@ def oss_process(filename):
                   '206fcbe2-47b3-41e8-98e6-8909595b8605')
     s = s.replace('b30c9262-9abf-4cd1-9476-adcf5723c029',
                   'b88526b7-3966-43fd-ae76-1e39881c86aa')
-    # TODO: Replace LockGuard texture UUIDs
 
     # OpenSim 0.8.0 does not support this constant.
     #s = s.replace('OBJECT_BODY_SHAPE_TYPE', '26 /*OBJECT_BODY_SHAPE_TYPE*/')
@@ -70,8 +76,86 @@ def oss_process(filename):
     s = os_line_re.sub(r'\1\2', s)
     s = sl_block_re.sub('', s)
     s = os_block_re.sub(r'\1', s)
+
+    new = ''
+    for match in token_re.finditer(s):
+        if match.group(1):
+            new += match.group(1)  # remove '#'
+        else:
+            new += match.group(0)
+    s = new
+
     sys.stdout.write(s)
     return 0
+
+def setvars(filename, *settings):
+    """Preprocess a file in place, to replace values"""
+    import re
+
+    values = {}
+    var_value_re = re.compile(r'^([^=]*)=(.*)$')
+    for v in settings:
+        match = var_value_re.search(v)
+        if not match:
+            sys.stderr.write('Incorrect setting format, it should be key=value\n')
+            return 1
+        values[match.group(1)] = match.group(2)
+
+    #sys.stderr.write(filename + '\n')
+    if filename is not None:
+        f = open(filename, "r")
+    else:
+        f = sys.stdin
+    try:
+        s = f.read()
+    finally:
+        if filename is not None:
+            f.close()
+
+    orig = s
+    # Regex to read a token in the set of expected tokens.
+    # NOTE: This regex deliberately ignores // so that //#variable = value; is still valid.
+    token_re = re.compile(r'"(?:\\.|[^"\\]+)*"|/\*[\S\s]*?\*/|/|;|[^#;/"]+|#([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*|#')
+    p = 0
+    while True:
+        match = token_re.search(s, p)
+        if not match:
+            break
+        if match.group(1) in values:
+            # found '#variable = ' in the code, and variable matches
+            value = values[match.group(1)]
+            # mark the start of the value as the end of the match
+            vbegin = match.end(0)
+            while True:
+                # keep skipping tokens until we hit a ';'
+                p = match.end(0)
+                match = token_re.search(s, p)
+                if not match:
+                    # end of script? this is wrong but better don't crash
+                    vend = vbegin
+                    break
+                if match.group(0) == ';':
+                    # mark end of value before the matching ';'
+                    vend = match.start(0)
+                    break
+            # Replace the value between vbegin and vend
+            s = s[:vbegin] + value + s[vend:]
+            # Advance past the value to keep searching
+            p = vbegin + len(value)
+            continue
+        # not a token we're interested in - keep searching after it
+        p = match.end(0)
+
+    if s != orig:
+        if filename is not None:
+            f = open(filename, "w")
+        else:
+            f = sys.stdout
+        try:
+            f.write(s)
+        finally:
+            if filename is not None:
+                f.close()
 
 def main(argc, argv):
     if argc < 2:
@@ -81,6 +165,9 @@ def main(argc, argv):
     cmd = argv[1]
     if cmd == 'rm':
         return rm(argv[2:])
+
+    if cmd == 'setvars':
+        return setvars(argv[2], *argv[3:])
 
     if cmd == 'oss-process':
         if argc > 3:


### PR DESCRIPTION
Change the build system to include version numbers in the scripts, which closes AVsitter/avsitter.github.io#46.

Change the versioning scheme to 2.2pXX for work-in-progress versions / pre-release versions, and 2.2rXX for releases.
