### PR TITLE
The RLV status report channel should not be 0

### DIFF
--- a/AVsitter2/Plugins/AVcontrol/[AV]root-RLV-extra.lsl
+++ b/AVsitter2/Plugins/AVcontrol/[AV]root-RLV-extra.lsl
@@ -184,7 +184,7 @@ state running
             llListenRemove(menu_handle);
             llListenRemove(GETSTATUShandle);
             menu_handle = llListen((menu_channel = ((integer)llFrand(0x7FFFFF80) + 1) * -1), "", CONTROLLER, ""); // 7FFFFF80 = max float < 2^31
-            GETSTATUShandle = llListen((RELAY_GETSTATUS_CHANNEL = (integer)llFrand(999999936)), "", "", ""); // 999999936 = max float < 1e9
+            GETSTATUShandle = llListen((RELAY_GETSTATUS_CHANNEL = 64 + (integer)llFrand(999999936)), "", "", ""); // 999999936 = max float < 1e9
             if (num == 90208)
             {
                 main_menu();


### PR DESCRIPTION
Random numbers can be zero. Avoid generating a channel with number zero.