### PR TITLE
Add warning to $check_ip in PHP about the cloud server migration

### DIFF
--- a/php/settings-config.inc.php
+++ b/php/settings-config.inc.php
@@ -11,4 +11,9 @@ $email_from="you@yourhost.com"; // your server's sending email (for error report
 
 $allow_install = false; // enable to allow action=install (clear/format database)
 
-$check_ip = false; // enable to check the sim ip submitting the data is in the allowed range
+// Enable to check if the sim IP submitting the data is in the allowed range.
+// WARNING: After the migration of SL to cloud servers, ensure this setting
+//          is set to FALSE, otherwise validation will always fail even for
+//          good addresses. If other means of verification are provided, this
+//          script will be updated accordingly.
+$check_ip = false;


### PR DESCRIPTION
As a consequence of the migration to cloud servers, the sim IPs will change, as announced in https://community.secondlife.com/forums/topic/460866-lsl-http-changes-coming

This means that the IP validation that was performed when `$check_ip` is set to `true` will stop working.

This PR adds a warning to the code in this respect.