### PR TITLE
Security: to enter a menu via listen, check that there's a TOMENU

### DIFF
--- a/AVsitter2/[AV]sitB.lsl
+++ b/AVsitter2/[AV]sitB.lsl
@@ -258,11 +258,14 @@ default
         index = llListFindList(MENU_LIST, ["M:" + msg]);
         if (index != -1)
         {
-            llMessageLinked(LINK_SET, 90051, (string)channel + "|" + llGetSubString(msg, 0, -2) + "|" + (string)SET, MY_SITTER);
-            menu_page = 0;
-            last_menu = current_menu;
-            current_menu = index;
-            animation_menu(0);
+            if (llListFindList(MENU_LIST, ["T:" + msg]) != -1) // security check - TOMENU must exist
+            {
+                llMessageLinked(LINK_SET, 90051, (string)channel + "|" + llGetSubString(msg, 0, -2) + "|" + (string)SET, MY_SITTER);
+                menu_page = 0;
+                last_menu = current_menu;
+                current_menu = index;
+                animation_menu(0);
+            }
             return;
         }
         index = llListFindList(llList2List(MENU_LIST, current_menu + 1, 99999), ["B:" + msg]);


### PR DESCRIPTION
Without this patch, hidden menus can be entered via chat if the person knows the menu channel. This channel is communicated to the viewer, therefore an attacker with a modified viewer can obtain it and use it to enter a hidden menu, if they know the hidden menu's name.

This is of special relevance for plug-ins that rely on this not being possible, such as #115, because it bypasses the security that they offer.

With this patch, a menu can't be entered if there is no corresponding `TOMENU` line.

**IMPORTANT NOTE:** This does not fully secure such menus. If they in turn contain submenus, these submenus can be entered in the same way. Therefore, access to these submenus should be blocked as well, so that there's no `TOMENU` for them either.
