### PR TITLE
Reuse the position/rotation vectors when they occur multiple times

### DIFF
--- a/AVsitter2/[AV]sitB.lsl
+++ b/AVsitter2/[AV]sitB.lsl
@@ -574,8 +574,19 @@ default
             {
                 if (index != -1)
                 {
-                    POS_ROT_LIST = llListReplaceList(POS_ROT_LIST, [(vector)llList2String(data, 1), (vector)llList2String(data, 2)], index * 2, index * 2 + 1);
-                    if (llGetListLength(data) != 3)
+                    one = llGetListLength(data);
+                    data = [(vector)llList2String(data, 1), (vector)llList2String(data, 2)];
+
+                    // LSL::
+                    // Reuse the preexisting vectors when possible, to save memory
+                    if ((two = llListFindList(POS_ROT_LIST, llList2List(data, 0, 0))) != -1)
+                        data = llList2List(POS_ROT_LIST, two, two) + llList2List(data, 1, 1);
+                    if ((two = llListFindList(POS_ROT_LIST, llList2List(data, 1, 1))) != -1)
+                        data = llList2List(data, 0, 0) + llList2List(POS_ROT_LIST, two, two);
+                    // ::LSL
+
+                    POS_ROT_LIST = llListReplaceList(POS_ROT_LIST, data, index * 2, index * 2 + 1);
+                    if (one != 3)
                     {
                         send_anim_info(FALSE);
                     }


### PR DESCRIPTION
This change has the potential of saving memory when there are multiple poses with the same position or rotation.

Based on a suggestion by @ohhmye (thanks).