### PR TITLE
Fix issues when using KFM

### DIFF
--- a/AVsitter2/[AV]sitA.lsl
+++ b/AVsitter2/[AV]sitA.lsl
@@ -426,12 +426,11 @@ sit_using_prim_params()
     if (HASKEYFRAME && !llGetStatus(STATUS_PHYSICS))
     {
         llSetKeyframedMotion([], [KFM_COMMAND, KFM_CMD_PAUSE]);
-        llSleep(0.15);
     }
     llSetLinkPrimitiveParamsFast(sitter_prim, [PRIM_ROT_LOCAL, llEuler2Rot((CURRENT_ROTATION + <0,0,0.002>) * DEG_TO_RAD) * localrot, PRIM_POS_LOCAL, CURRENT_POSITION * localrot + localpos]);
     if (HASKEYFRAME && !llGetStatus(STATUS_PHYSICS))
     {
-        llSleep(0.15);
+        llSleep(0.2);
         llSetKeyframedMotion([], [KFM_COMMAND, KFM_CMD_PLAY]);
     }
 }


### PR DESCRIPTION
I've got an issue reported several times by customers with furnitures moving with KFM. They get this error:
`Cannot use a script to move a linkset while it is playing an animation. Stop the animation first.`

Before this fix, the code follow this workflow:
- it pauses KFM
- it sleeps 0.15 seconds
- it updates the link position
- it sleeps 0.15 seconds
- it restarts KFM

I think you've inserted these 0.15 sleep before and after because both scripts `sitA` and `sitA 1` (and more if there are 3 or more sitters) can be slightly unsynced, so it is good to give a little delay to avoid that `sitA` restarts KFM while `sitA 1` hasn't changed the link position yet.

But it looks like the first llSleep is not only needless, but even increases the risk of error. Why sleeping 0.15 seconds between the KFM pause and the link position change? It makes the critical situation longer. The error occurs quite often. And it occurs almost everytime if both sitters select a pose roughly at the same time.

I did a test, sitting on a furniture with a friend. I asked her to click many times on all buttons. I was doing the same. In less than 30 seconds, i got the error 5 times.

Then i did the same test, removing the first llSleep, and keeping the second one, that i have increased a little bit to 0.2 seconds. Same test with this friend: 0 error. That's why i propose this change.