### PR TITLE
Allow splitting AVpos notecards into one per sitter

### DIFF
--- a/AVsitter2/[AV]sitA.lsl
+++ b/AVsitter2/[AV]sitA.lsl
@@ -472,6 +472,10 @@ default
         if (SCRIPT_CHANNEL)
         {
             memoryscript += " " + (string)SCRIPT_CHANNEL;
+            if (llGetInventoryType(notecard_name + " " + (string)SCRIPT_CHANNEL) == INVENTORY_NOTECARD)
+            {
+                notecard_name = notecard_name + " " + (string)SCRIPT_CHANNEL;
+            }
         }
         else
         {


### PR DESCRIPTION
This small change lets you split up your AVpos notecard into AVpos, AVpos 1, AVpos 2 and so on, similar to sitA+sitB, sitA 1+sitB 1.
This is useful if you are working on something like a vehicle where there is a large number of sitters. It drastically reduces notecard size, loading times and is easier to manage than one big file, matching the modularity that AVsitter is known for.
Splitting your notecards like this allows you to configure many more poses than you otherwise would be able to.

This PR does not break compatibility with using a single AVpos, which may be preferred in most cases. It is an entirely optional feature.

Known issues:
- Many plugins only read one notecard [AV]select and Missing-anim-finder come to mind and will need an update. I will look into this if this PR is accepted.